### PR TITLE
Fix typo in the OWNERS_ALIASES file

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,4 +1,4 @@
- See the OWNERS docs: https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+# See the OWNERS docs: https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
 
 aliases:
   operating-system-manager-maintainers:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix typo in the OWNERS_ALIASES file.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
