### PR TITLE
Preserve CloudProviderSpec.Spec field when storing OSPs and OSCs

### DIFF
--- a/charts/crd/crd-operating-system-config.yaml
+++ b/charts/crd/crd-operating-system-config.yaml
@@ -71,6 +71,7 @@ spec:
                     description: Spec represents the os/image reference in the supported
                       cloud provider
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
               files:
                 description: Files is a list of files that should exist in the instance
                 type: array

--- a/charts/crd/crd-operating-system-profile.yaml
+++ b/charts/crd/crd-operating-system-profile.yaml
@@ -122,6 +122,7 @@ spec:
                       description: Spec represents the os/image reference in the supported
                         cloud provider
                       type: object
+                      x-kubernetes-preserve-unknown-fields: true
               units:
                 description: Units a list of the systemd unit files which will run
                   on the instance

--- a/pkg/crd/osm/v1alpha1/common_types.go
+++ b/pkg/crd/osm/v1alpha1/common_types.go
@@ -25,6 +25,7 @@ type CloudProviderSpec struct {
 	// Name represents the name of the supported cloud provider
 	Name string `json:"name"`
 	// Spec represents the os/image reference in the supported cloud provider
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Spec runtime.RawExtension `json:"spec"`
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

By default, `runtime.RawExtension` fields are pruned when storing CustomResources because they're considered as unknown fields. As per the [Kubernetes docs](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#rawextension), this behavior can be changed by using `x-kubernetes-embedded-resource` and `x-kubernetes-preserve-unknown-fields` fields in the OpenAPI scheme.

We're using only `x-kubernetes-preserve-unknown-fields` because `x-kubernetes-embedded-resource` is used to annotate that a field will store the whole Kubernetes object, so it validates is `apiVersion`, `kind`, and `metadata` present.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @moelsayed @moadqassem 