### PR TITLE
OSC namespace replaced by cloud-init-settings

### DIFF
--- a/cmd/osm-controller/main.go
+++ b/cmd/osm-controller/main.go
@@ -97,7 +97,6 @@ func main() {
 		opt.kubeconfig = getKubeConfigPath()
 	}
 
-
 	parsedClusterDNSIPs, err := parseClusterDNSIPs(opt.clusterDNSIPs)
 	if err != nil {
 		klog.Fatalf("invalid cluster dns specified: %v", err)
@@ -129,7 +128,7 @@ func main() {
 	if err := osc.Add(
 		mgr,
 		log,
-		opt.namespace,
+		osc.CloudInitSettingsNamespace,
 		opt.clusterName,
 		opt.workerCount,
 		parsedClusterDNSIPs,

--- a/pkg/controllers/osc/osc_controller.go
+++ b/pkg/controllers/osc/osc_controller.go
@@ -47,6 +47,8 @@ const (
 	// MachineDeploymentCleanupFinalizer indicates that sub-resources created by OSC controller against a MachineDeployment should be deleted
 	MachineDeploymentCleanupFinalizer = "kubermatic.io/cleanup-operating-system-configs"
 	cloudConfigSecretName             = "cloud-config"
+	// CloudInitSettingsNamespace is the namespace in which OSCs and secrets are created by OSC controller
+	CloudInitSettingsNamespace = "cloud-init-settings"
 )
 
 type Reconciler struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR replaces the parameterized namespace by cloud-init-settings namespace, in which OSCs and secrets will be created.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
