### PR TITLE
Support RHEL in OSM

### DIFF
--- a/cmd/osm-controller/main.go
+++ b/cmd/osm-controller/main.go
@@ -53,6 +53,8 @@ type options struct {
 	containerdVersion     string
 	nodeHTTPProxy         string
 	nodeNoProxy           string
+	nodePortRange         string
+	podCidr               string
 
 	clusterDNSIPs string
 	kubeconfig    string
@@ -79,6 +81,8 @@ func main() {
 	flag.StringVar(&opt.containerdVersion, "containerd-version", "", "Containerd version to use in the cluster.")
 	flag.StringVar(&opt.nodeHTTPProxy, "node-http-proxy", "", "If set, it configures the 'HTTP_PROXY' & 'HTTPS_PROXY' environment variable on the nodes.")
 	flag.StringVar(&opt.nodeNoProxy, "node-no-proxy", ".svc,.cluster.local,localhost,127.0.0.1", "If set, it configures the 'NO_PROXY' environment variable on the nodes.")
+	flag.StringVar(&opt.podCidr, "pod-cidr", "172.25.0.0/16", "The network ranges from which POD networks are allocated")
+	flag.StringVar(&opt.nodePortRange, "node-port-range", "30000-32767", "A port range to reserve for services with NodePort visibility")
 
 	flag.Parse()
 
@@ -151,6 +155,8 @@ func main() {
 		opt.containerdVersion,
 		opt.nodeHTTPProxy,
 		opt.nodeNoProxy,
+		opt.nodePortRange,
+		opt.podCidr,
 	); err != nil {
 		klog.Fatal(err)
 	}

--- a/examples/osp-rhel.yaml
+++ b/examples/osp-rhel.yaml
@@ -1,0 +1,544 @@
+# Copyright 2021 The Operating System Manager contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: operatingsystemmanager.k8c.io/v1alpha1
+kind: OperatingSystemProfile
+metadata:
+  name: osp-rhel
+  namespace: cloud-init-settings
+spec:
+  osName: "rhel"
+  osVersion: "8.4"
+  supportedCloudProviders:
+    - name: "aws"
+    - name: "azure"
+    - name: "kubevirt"
+    - name: "openstack"
+    - name: "vsphere"
+  supportedContainerRuntimes:
+    - name: containerd
+      files:
+        - path: "/etc/containerd/config.toml"
+          permissions: 0644
+          content:
+            inline:
+              encoding: b64
+              data: |
+                version = 2
+
+                [metrics]
+                address = "127.0.0.1:1338"
+
+                [plugins]
+                [plugins."io.containerd.grpc.v1.cri"]
+                [plugins."io.containerd.grpc.v1.cri".containerd]
+                [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+                [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+                runtime_type = "io.containerd.runc.v2"
+                [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+                SystemdCgroup = true
+                [plugins."io.containerd.grpc.v1.cri".registry]
+                [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+                [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+                endpoint = ["https://registry-1.docker.io"]
+      templates:
+        containerRuntimeInstallation: |-
+          yum install -y yum-utils
+          yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+          {{- /*
+              Due to DNF modules we have to do this on docker-ce repo
+              More info at: https://bugzilla.redhat.com/show_bug.cgi?id=1756473
+          */}}
+          yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
+
+          cat <<EOF | tee /etc/crictl.yaml
+          runtime-endpoint: unix:///run/containerd/containerd.sock
+          EOF
+
+          mkdir -p /etc/systemd/system/containerd.service.d
+          cat <<EOF | tee /etc/systemd/system/containerd.service.d/environment.conf
+          [Service]
+          Restart=always
+          EnvironmentFile=-/etc/environment
+          EOF
+
+          yum install -y containerd.io-{{ .ContainerdVersion }}* yum-plugin-versionlock
+          yum versionlock add containerd.io
+
+          systemctl daemon-reload
+          systemctl enable --now containerd
+
+    - name: docker
+      files:
+        - path: /etc/docker/daemon.json
+          permissions: 0644
+          content:
+            inline:
+              encoding: b64
+              data: |-
+                {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","log-driver":"json-file","log-opts":{"max-file":"5","max-size":"10m"}}
+      templates:
+        containerRuntimeInstallation: |-
+          yum install -y yum-utils
+          yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+          yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
+
+          mkdir -p /etc/systemd/system/containerd.service.d /etc/systemd/system/docker.service.d
+
+          cat <<EOF | tee /etc/systemd/system/containerd.service.d/environment.conf /etc/systemd/system/docker.service.d/environment.conf
+          [Service]
+          Restart=always
+          EnvironmentFile=-/etc/environment
+          EOF
+
+          yum install -y \
+              docker-ce-cli-19.03* \
+              containerd.io-1.4* \
+              docker-ce-19.03* \
+              yum-plugin-versionlock
+          yum versionlock add docker-ce* containerd.io
+
+          systemctl daemon-reload
+          systemctl enable --now docker
+
+  templates:
+    safeDownloadBinariesScript: |-
+      {{- /*setup some common directories */ -}}
+      opt_bin=/opt/bin
+      cni_bin_dir=/opt/cni/bin
+
+      {{- /* create all the necessary dirs */}}
+      mkdir -p /etc/cni/net.d /etc/kubernetes/dynamic-config-dir /etc/kubernetes/manifests "$opt_bin" "$cni_bin_dir"
+
+      {{- /* HOST_ARCH can be defined outside of machine-controller (in kubeone for example) */}}
+      arch=${HOST_ARCH-}
+      if [ -z "$arch" ]
+      then
+      case $(uname -m) in
+      x86_64)
+          arch="amd64"
+          ;;
+      aarch64)
+          arch="arm64"
+          ;;
+      *)
+          echo "unsupported CPU architecture, exiting"
+          exit 1
+          ;;
+      esac
+      fi
+
+      {{- /* # CNI variables */}}
+      CNI_VERSION="${CNI_VERSION:-{{ .CNIVersion }}}"
+      cni_base_url="https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION"
+      cni_filename="cni-plugins-linux-$arch-$CNI_VERSION.tgz"
+
+      {{- /* download CNI */}}
+      curl -Lfo "$cni_bin_dir/$cni_filename" "$cni_base_url/$cni_filename"
+
+      {{- /* download CNI checksum */}}
+      cni_sum=$(curl -Lf "$cni_base_url/$cni_filename.sha256")
+      cd "$cni_bin_dir"
+
+      {{- /* verify CNI checksum */}}
+      sha256sum -c <<<"$cni_sum"
+
+      {{- /* unpack CNI */}}
+      tar xvf "$cni_filename"
+      rm -f "$cni_filename"
+      cd -
+
+      {{- /* kubelet */}}
+      KUBE_VERSION="${KUBE_VERSION:-{{ .KubeVersion }}}"
+      kube_dir="$opt_bin/kubernetes-$KUBE_VERSION"
+      kube_base_url="https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$arch"
+      kube_sum_file="$kube_dir/sha256"
+
+      {{- /* create versioned kube dir */}}
+      mkdir -p "$kube_dir"
+      : >"$kube_sum_file"
+
+      for bin in kubelet kubeadm kubectl; do
+          {{- /* download kube binary */}}
+          curl -Lfo "$kube_dir/$bin" "$kube_base_url/$bin"
+          chmod +x "$kube_dir/$bin"
+
+          {{- /* download kube binary checksum */}}
+          sum=$(curl -Lf "$kube_base_url/$bin.sha256")
+
+          {{- /* save kube binary checksum */}}
+          echo "$sum  $kube_dir/$bin" >>"$kube_sum_file"
+      done
+
+      {{- /* check kube binaries checksum */}}
+      sha256sum -c "$kube_sum_file"
+
+      for bin in kubelet kubeadm kubectl; do
+          {{- /* link kube binaries from verioned dir to $opt_bin */}}
+          ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
+      done
+
+      if [[ ! -x /opt/bin/health-monitor.sh ]]; then
+          curl -Lfo /opt/bin/health-monitor.sh https://raw.githubusercontent.com/kubermatic/machine-controller/7967a0af2b75f29ad2ab227eeaa26ea7b0f2fbde/pkg/userdata/scripts/health-monitor.sh
+          chmod +x /opt/bin/health-monitor.sh
+      fi
+
+    configureProxyScript: |-
+      {{- if .HTTPProxy }}
+      cat <<EOF | tee -a /etc/environment
+      HTTP_PROXY={{ .HTTPProxy }}
+      http_proxy={{ .HTTPProxy }}
+      HTTPS_PROXY={{ .HTTPProxy }}
+      https_proxy={{ .HTTPProxy }}
+      NO_PROXY={{ .NoProxy }}
+      no_proxy={{ .NoProxy }}
+      EOF
+      {{- end }}
+
+  files:
+    - path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
+      content:
+        inline:
+          encoding: b64
+          data: |
+            [Journal]
+            SystemMaxUse=5G
+
+    - path: "/opt/load-kernel-modules.sh"
+      permissions: 0755
+      content:
+        inline:
+          encoding: b64
+          data: |
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            modprobe ip_vs
+            modprobe ip_vs_rr
+            modprobe ip_vs_wrr
+            modprobe ip_vs_sh
+
+            if modinfo nf_conntrack_ipv4 &> /dev/null; then
+              modprobe nf_conntrack_ipv4
+            else
+              modprobe nf_conntrack
+            fi
+
+    - path: "/etc/sysctl.d/k8s.conf"
+      content:
+        inline:
+          encoding: b64
+          data: |
+            net.bridge.bridge-nf-call-ip6tables = 1
+            net.bridge.bridge-nf-call-iptables = 1
+            kernel.panic_on_oops = 1
+            kernel.panic = 10
+            net.ipv4.ip_forward = 1
+            vm.overcommit_memory = 1
+            fs.inotify.max_user_watches = 1048576
+
+    - path: "/etc/selinux/config"
+      content:
+        inline:
+          encoding: b64
+          data: |
+            # This file controls the state of SELinux on the system.
+            # SELINUX= can take one of these three values:
+            #     enforcing - SELinux security policy is enforced.
+            #     permissive - SELinux prints warnings instead of enforcing.
+            #     disabled - No SELinux policy is loaded.
+            SELINUX=permissive
+            # SELINUXTYPE= can take one of three two values:
+            #     targeted - Targeted processes are protected,
+            #     minimum - Modification of targeted policy. Only selected processes are protected.
+            #     mls - Multi Level Security protection.
+            SELINUXTYPE=targeted
+
+
+
+    - path: "/opt/bin/setup"
+      permissions: 0755
+      content:
+        inline:
+          encoding: b64
+          data: |
+            #!/bin/bash
+            set -xeuo pipefail
+
+            setenforce 0 || true
+
+            {{- /* As we added some modules and don't want to reboot, restart the service */}}
+            systemctl restart systemd-modules-load.service
+            sysctl --system
+
+            {{- /* Make sure we always disable swap - Otherwise the kubelet won't start'. */}}
+            sed -i.orig '/.*swap.*/d' /etc/fstab
+            swapoff -a
+
+            {{ if eq .CloudProviderName "azure" }}
+            yum update -y --disablerepo='*' --enablerepo='*microsoft*'
+            firewall-cmd --permanent --zone=trusted --add-source={{ .PodCIDR }}
+            firewall-cmd --permanent --add-port=8472/udp
+            firewall-cmd --permanent --add-port={{ .NodePortRange }}/tcp
+            firewall-cmd --permanent --add-port={{ .NodePortRange }}/udp
+            firewall-cmd --reload
+            systemctl restart firewalld
+            {{ end }}
+            yum install -y \
+              device-mapper-persistent-data \
+              lvm2 \
+              ebtables \
+              ethtool \
+              nfs-utils \
+              bash-completion \
+              sudo \
+              socat \
+              wget \
+              curl \
+              {{- if eq .CloudProviderName "vsphere" }}
+              open-vm-tools \
+              {{- end }}
+              ipvsadm
+
+            {{- template "containerRuntimeInstallation" }}
+
+            {{- template "safeDownloadBinariesScript" }}
+
+            mkdir -p /etc/systemd/system/kubelet.service.d/
+            # set kubelet nodeip environment variable
+            /opt/bin/setup_net_env.sh
+
+            {{ if eq .CloudProviderName "vsphere" }}
+            systemctl enable --now vmtoolsd.service
+            {{ end -}}
+            systemctl enable --now kubelet
+            systemctl enable --now --no-block kubelet-healthcheck.service
+
+    - path: "/opt/bin/supervise.sh"
+      permissions: 0755
+      content:
+        inline:
+          encoding: b64
+          data: |
+            #!/bin/bash
+            set -xeuo pipefail
+            while ! "$@"; do
+              sleep 1
+            done
+
+    - path: "/etc/systemd/system/kubelet.service"
+      content:
+        inline:
+          encoding: b64
+          data: |
+            [Unit]
+            After={{ .ContainerRuntime }}.service
+            Requires={{ .ContainerRuntime }}.service
+
+            Description=kubelet: The Kubernetes Node Agent
+            Documentation=https://kubernetes.io/docs/home/
+
+            [Service]
+            Restart=always
+            StartLimitInterval=0
+            RestartSec=10
+            CPUAccounting=true
+            MemoryAccounting=true
+
+            Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+            EnvironmentFile=-/etc/environment
+
+            ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
+            ExecStartPre=/bin/bash /opt/bin/setup_net_env.sh
+            ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
+              --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
+              --kubeconfig=/var/lib/kubelet/kubeconfig \
+              --config=/etc/kubernetes/kubelet.conf \
+              --network-plugin=cni \
+              --cert-dir=/etc/kubernetes/pki \
+              {{- if .ExternalCloudProvider }}
+              --cloud-provider=external \
+              {{- else if .CloudProviderName }}
+              --cloud-provider={{- .CloudProviderName}} \
+              --cloud-config=/etc/kubernetes/cloud-config \
+              {{- end }}
+              {{- if ne .CloudProviderName "aws" }}
+              --hostname-override=${KUBELET_HOSTNAME} \
+              {{- end }}
+              --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
+              --feature-gates=DynamicKubeletConfig=true \
+              --exit-on-lock-contention \
+              --lock-file=/tmp/kubelet.lock \
+              {{- if .PauseImage }}
+              --pod-infra-container-image={{ .PauseImage }} \
+              {{- end }}
+              {{- if .InitialTaints }}
+              --register-with-taints={{- .InitialTaints }} \
+              {{- end }}
+              {{- if eq .ContainerRuntime "containerd" }}
+              --container-runtime=remote \
+              --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+              {{- end }}
+              {{- if eq .ContainerRuntime "docker" }}
+              --container-runtime=docker \
+              --container-runtime-endpoint=unix:///var/run/dockershim.sock \
+              {{- end }}
+              --node-ip ${KUBELET_NODE_IP}
+
+            [Install]
+            WantedBy=multi-user.target
+
+    - path: "/etc/kubernetes/cloud-config"
+      permissions: 0600
+      content:
+        inline:
+          encoding: b64
+          data: |
+            {{ .CloudConfig }}
+
+    - path: "/opt/bin/setup_net_env.sh"
+      permissions: 0755
+      content:
+        inline:
+          encoding: b64
+          data: |
+            #!/usr/bin/env bash
+            echodate() {
+              echo "[$(date -Is)]" "$@"
+            }
+
+            # get the default interface IP address
+            DEFAULT_IFC_IP=$(ip -o  route get 1 | grep -oP "src \K\S+")
+
+            if [ -z "${DEFAULT_IFC_IP}" ]
+            then
+              echodate "Failed to get IP address for the default route interface"
+              exit 1
+            fi
+
+             # get the full hostname
+            FULL_HOSTNAME=$(hostname -f)
+
+            # write the nodeip_env file
+            # we need the line below because flatcar has the same string "coreos" in that file
+            if grep -q coreos /etc/os-release
+            then
+              echo "KUBELET_NODE_IP=${DEFAULT_IFC_IP}\nKUBELET_HOSTNAME=${FULL_HOSTNAME}" > /etc/kubernetes/nodeip.conf
+            elif [ ! -d /etc/systemd/system/kubelet.service.d ]
+            then
+              echodate "Can't find kubelet service extras directory"
+              exit 1
+            else
+              echo -e "[Service]\nEnvironment=\"KUBELET_NODE_IP=${DEFAULT_IFC_IP}\"\nEnvironment=\"KUBELET_HOSTNAME=${FULL_HOSTNAME}\"" > /etc/systemd/system/kubelet.service.d/nodeip.conf
+            fi
+
+    - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+      permissions: 0600
+      content:
+        inline:
+          encoding: b64
+          data: |
+            {{ .Kubeconfig }}
+
+    - path: "/etc/kubernetes/pki/ca.crt"
+      content:
+        inline:
+          encoding: b64
+          data: |
+            {{ .KubernetesCACert }}
+
+    - path: "/etc/systemd/system/setup.service"
+      permissions: 0644
+      content:
+        inline:
+          encoding: b64
+          data: |
+            [Install]
+            WantedBy=multi-user.target
+
+            [Unit]
+            Requires=network-online.target
+            After=network-online.target
+
+            [Service]
+            Type=oneshot
+            RemainAfterExit=true
+            EnvironmentFile=-/etc/environment
+            ExecStart=/opt/bin/supervise.sh /opt/bin/setup
+
+    - path: "/etc/profile.d/opt-bin-path.sh"
+      permissions: 0644
+      content:
+        inline:
+          encoding: b64
+          data: |
+            export PATH="/opt/bin:$PATH"
+
+    - path: "/etc/kubernetes/kubelet.conf"
+      content:
+        inline:
+          encoding: b64
+          data: |
+            apiVersion: kubelet.config.k8s.io/v1beta1
+            kind: KubeletConfiguration
+            authentication:
+              anonymous:
+                enabled: false
+              webhook:
+                enabled: true
+              x509:
+                clientCAFile: /etc/kubernetes/pki/ca.crt
+            authorization:
+              mode: Webhook
+            cgroupDriver: systemd
+            clusterDNS:
+            {{- range .ClusterDNSIPs }}
+            - "{{ . }}"
+            {{- end }}
+            clusterDomain: cluster.local
+            featureGates:
+              RotateKubeletServerCertificate: true
+            protectKernelDefaults: true
+            readOnlyPort: 0
+            rotateCertificates: true
+            serverTLSBootstrap: true
+            staticPodPath: /etc/kubernetes/manifests
+            kubeReserved:
+              cpu: 200m
+              ephemeral-storage: 1Gi
+              memory: 200Mi
+            systemReserved:
+              cpu: 200m
+              ephemeral-storage: 1Gi
+              memory: 200Mi
+            volumePluginDir: /var/lib/kubelet/volumeplugins
+
+    - path: /etc/systemd/system/kubelet-healthcheck.service
+      permissions: 0644
+      content:
+        inline:
+          encoding: b64
+          data: |
+            [Unit]
+            Requires=kubelet.service
+            After=kubelet.service
+
+            [Service]
+            ExecStart=/opt/bin/health-monitor.sh kubelet
+
+            [Install]
+            WantedBy=multi-user.target
+  modules:
+    - bootcmd:
+        - modprobe ip_tables

--- a/pkg/controllers/osc/osc_controller.go
+++ b/pkg/controllers/osc/osc_controller.go
@@ -66,6 +66,8 @@ type Reconciler struct {
 	containerdVersion     string
 	nodeHTTPProxy         string
 	nodeNoProxy           string
+	podCIDR               string
+	nodePortRange         string
 }
 
 func Add(
@@ -84,7 +86,9 @@ func Add(
 	cniVersion string,
 	containerdVersion string,
 	nodeHTTPProxy string,
-	nodeNoProxy string) error {
+	nodeNoProxy string,
+	podCIDR string,
+	nodePortRange string) error {
 	reconciler := &Reconciler{
 		Client:                mgr.GetClient(),
 		log:                   log,
@@ -101,6 +105,8 @@ func Add(
 		containerdVersion:     containerdVersion,
 		nodeHTTPProxy:         nodeHTTPProxy,
 		nodeNoProxy:           nodeNoProxy,
+		podCIDR:               podCIDR,
+		nodePortRange:         nodePortRange,
 	}
 	log.Info("Reconciling OSC resource..")
 	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: workerCount})
@@ -191,6 +197,8 @@ func (r *Reconciler) reconcileOperatingSystemConfigs(ctx context.Context, md *cl
 			r.containerdVersion,
 			r.nodeHTTPProxy,
 			r.nodeNoProxy,
+			r.nodePortRange,
+			r.podCIDR,
 		),
 	}, r.namespace, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile provisioning operating system config: %v", err)

--- a/pkg/controllers/osc/resources/operating_system_config.go
+++ b/pkg/controllers/osc/resources/operating_system_config.go
@@ -64,6 +64,8 @@ func OperatingSystemConfigCreator(
 	containerdVersion string,
 	nodeHTTPProxy string,
 	nodeNoProxy string,
+	nodePortRange string,
+	podCidr string,
 ) reconciling.NamedOperatingSystemConfigCreatorGetter {
 	return func() (string, reconciling.OperatingSystemConfigCreator) {
 		var oscName = fmt.Sprintf(MachineDeploymentSubresourceNamePattern, md.Name, ProvisioningCloudConfig)
@@ -116,6 +118,8 @@ func OperatingSystemConfigCreator(
 				ExternalCloudProvider: externalCloudProvider,
 				PauseImage:            pauseImage,
 				InitialTaints:         initialTaints,
+				PodCIDR:               podCidr,
+				NodePortRange:         nodePortRange,
 			}
 
 			if len(nodeHTTPProxy) > 0 {
@@ -181,6 +185,8 @@ type filesData struct {
 	InitialTaints         string
 	HTTPProxy             *string
 	NoProxy               *string
+	PodCIDR               string
+	NodePortRange         string
 	OperatingSystemConfig
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Basic support for RHEL in OSM. The current template is used for provisioning rhel with SCA policy(no need to attach a subscription for the machine)
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #83

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support RHEL in OSM 
```
