### PR TITLE
Refactor OSP templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ build: $(CMD)
 $(CMD): %: $(BUILD_DEST)/%
 
 $(BUILD_DEST)/%: cmd/%
-	go build -o $@ ./cmd/$*
+	go build -v -o $@ ./cmd/$*
 
 .PHONY: run
 run:

--- a/deploy/osps/default/osp-amzn2.yaml
+++ b/deploy/osps/default/osp-amzn2.yaml
@@ -32,6 +32,14 @@ spec:
               data: |
                 runtime-endpoint: unix:///run/containerd/containerd.sock
 
+        - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
         - path: "/etc/containerd/config.toml"
           permissions: 0600
           content:
@@ -51,6 +59,22 @@ spec:
 
     - name: docker
       files:
+        - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
+        - path: "/etc/systemd/system/docker.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
         - path: /etc/docker/daemon.json
           permissions: 0644
           content:
@@ -182,22 +206,6 @@ spec:
       {{- end }}
 
   files:
-    - path: "/etc/systemd/system/containerd.service.d/environment.conf"
-      content:
-        inline:
-          data: |
-            [Service]
-            Restart=always
-            EnvironmentFile=-/etc/environment
-
-    - path: "/etc/systemd/system/docker.service.d/environment.conf"
-      content:
-        inline:
-          data: |
-            [Service]
-            Restart=always
-            EnvironmentFile=-/etc/environment
-
     - path: "/opt/bin/health-monitor.sh"
       permissions: 0755
       content:

--- a/deploy/osps/default/osp-amzn2.yaml
+++ b/deploy/osps/default/osp-amzn2.yaml
@@ -20,33 +20,27 @@ metadata:
 spec:
   osName: "amzn2"
   osVersion: "2.0"
-  version: "v0.1.1"
+  version: "v0.1.2"
   supportedCloudProviders:
     - name: "aws"
   supportedContainerRuntimes:
     - name: containerd
       files:
+        - path: "/etc/crictl.yaml"
+          content:
+            inline:
+              data: |
+                runtime-endpoint: unix:///run/containerd/containerd.sock
+
         - path: "/etc/containerd/config.toml"
-          permissions: 0644
+          permissions: 0600
           content:
             inline:
               encoding: b64
               data: |
-                {{ .ContainerRuntimeConfig}}
+                {{ .ContainerRuntimeConfig }}
       templates:
         containerRuntimeInstallation: |-
-          mkdir -p /etc/systemd/system/containerd.service.d
-
-          cat <<EOF | tee /etc/systemd/system/containerd.service.d/environment.conf
-          [Service]
-          Restart=always
-          EnvironmentFile=-/etc/environment
-          EOF
-
-          cat <<EOF | tee /etc/crictl.yaml
-          runtime-endpoint: unix:///run/containerd/containerd.sock
-          EOF
-
           yum install -y \
           	containerd-1.4* \
           	yum-plugin-versionlock
@@ -63,17 +57,9 @@ spec:
             inline:
               encoding: b64
               data: |-
-                {{ .ContainerRuntimeConfig}}
+                {{ .ContainerRuntimeConfig }}
       templates:
         containerRuntimeInstallation: |-
-          mkdir -p /etc/systemd/system/containerd.service.d /etc/systemd/system/docker.service.d
-
-          cat <<EOF | tee /etc/systemd/system/containerd.service.d/environment.conf /etc/systemd/system/docker.service.d/environment.conf
-          [Service]
-          Restart=always
-          EnvironmentFile=-/etc/environment
-          EOF
-
           yum install -y \
               containerd-1.4* \
               docker-19.03* \
@@ -90,10 +76,10 @@ spec:
       usr_local_bin=/usr/local/bin
       cni_bin_dir=/opt/cni/bin
 
-      {{- /* create all the necessary dirs */}}
+      {{- /* create all the necessary dirs */ }}
       mkdir -p /etc/cni/net.d /etc/kubernetes/dynamic-config-dir /etc/kubernetes/manifests "$opt_bin" "$cni_bin_dir"
 
-      {{- /* HOST_ARCH can be defined outside of machine-controller (in kubeone for example) */}}
+      {{- /* HOST_ARCH can be defined outside of machine-controller (in kubeone for example) */ }}
       arch=${HOST_ARCH-}
       if [ -z "$arch" ]
       then
@@ -111,82 +97,77 @@ spec:
       esac
       fi
 
-      {{- /* # CNI variables */}}
+      {{- /* # CNI variables */ }}
       CNI_VERSION="${CNI_VERSION:-v0.8.7}"
       cni_base_url="https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION"
       cni_filename="cni-plugins-linux-$arch-$CNI_VERSION.tgz"
 
-      {{- /* download CNI */}}
+      {{- /* download CNI */ }}
       curl -Lfo "$cni_bin_dir/$cni_filename" "$cni_base_url/$cni_filename"
 
-      {{- /* download CNI checksum */}}
+      {{- /* download CNI checksum */ }}
       cni_sum=$(curl -Lf "$cni_base_url/$cni_filename.sha256")
       cd "$cni_bin_dir"
 
-      {{- /* verify CNI checksum */}}
+      {{- /* verify CNI checksum */ }}
       sha256sum -c <<<"$cni_sum"
 
-      {{- /* unpack CNI */}}
+      {{- /* unpack CNI */ }}
       tar xvf "$cni_filename"
       rm -f "$cni_filename"
       cd -
 
-      {{- /* # cri-tools variables */}}
+      {{- /* # cri-tools variables */ }}
       CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.22.0}"
       cri_tools_base_url="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}"
       cri_tools_filename="crictl-${CRI_TOOLS_RELEASE}-linux-${arch}.tar.gz"
 
-      {{- /* download cri-tools */}}
+      {{- /* download cri-tools */ }}
       curl -Lfo "$opt_bin/$cri_tools_filename" "$cri_tools_base_url/$cri_tools_filename"
 
-      {{- /* download cri-tools checksum */}}
-      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */}}
+      {{- /* download cri-tools checksum */ }}
+      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */ }}
       cri_tools_sum=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256" | sed 's/\*\///')
       cd "$opt_bin"
 
-      {{- /* verify cri-tools checksum */}}
+      {{- /* verify cri-tools checksum */ }}
       sha256sum -c <<<"$cri_tools_sum"
 
-      {{- /* unpack cri-tools and symlink to path so it's available to all users */}}
+      {{- /* unpack cri-tools and symlink to path so it's available to all users */ }}
       tar xvf "$cri_tools_filename"
       rm -f "$cri_tools_filename"
       ln -sf "$opt_bin/crictl" "$usr_local_bin"/crictl || echo "symbolic link is skipped"
       cd -
 
-      {{- /* kubelet */}}
+      {{- /* kubelet */ }}
       KUBE_VERSION="${KUBE_VERSION:-{{ .KubeVersion }}}"
       kube_dir="$opt_bin/kubernetes-$KUBE_VERSION"
       kube_base_url="https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$arch"
       kube_sum_file="$kube_dir/sha256"
 
-      {{- /* create versioned kube dir */}}
+      {{- /* create versioned kube dir */ }}
       mkdir -p "$kube_dir"
       : >"$kube_sum_file"
 
       for bin in kubelet kubeadm kubectl; do
-          {{- /* download kube binary */}}
+          {{- /* download kube binary */ }}
           curl -Lfo "$kube_dir/$bin" "$kube_base_url/$bin"
           chmod +x "$kube_dir/$bin"
 
-          {{- /* download kube binary checksum */}}
+          {{- /* download kube binary checksum */ }}
           sum=$(curl -Lf "$kube_base_url/$bin.sha256")
 
-          {{- /* save kube binary checksum */}}
+          {{- /* save kube binary checksum */ }}
           echo "$sum  $kube_dir/$bin" >>"$kube_sum_file"
       done
 
-      {{- /* check kube binaries checksum */}}
+      {{- /* check kube binaries checksum */ }}
       sha256sum -c "$kube_sum_file"
 
       for bin in kubelet kubeadm kubectl; do
-          {{- /* link kube binaries from verioned dir to $opt_bin */}}
+          {{- /* link kube binaries from verioned dir to $opt_bin */ }}
           ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
       done
-
-      if [[ ! -x /opt/bin/health-monitor.sh ]]; then
-          curl -Lfo /opt/bin/health-monitor.sh https://raw.githubusercontent.com/kubermatic/machine-controller/7967a0af2b75f29ad2ab227eeaa26ea7b0f2fbde/pkg/userdata/scripts/health-monitor.sh
-          chmod +x /opt/bin/health-monitor.sh
-      fi
 
     configureProxyScript: |-
       {{- if .HTTPProxy }}
@@ -201,6 +182,146 @@ spec:
       {{- end }}
 
   files:
+    - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+      content:
+        inline:
+          data: |
+            [Service]
+            Restart=always
+            EnvironmentFile=-/etc/environment
+
+    - path: "/etc/systemd/system/docker.service.d/environment.conf"
+      content:
+        inline:
+          data: |
+            [Service]
+            Restart=always
+            EnvironmentFile=-/etc/environment
+
+    - path: "/opt/bin/health-monitor.sh"
+      permissions: 0755
+      content:
+        inline:
+          encoding: b64
+          data: |
+            #!/usr/bin/env bash
+
+            # Copyright 2016 The Kubernetes Authors.
+            #
+            # Licensed under the Apache License, Version 2.0 (the "License");
+            # you may not use this file except in compliance with the License.
+            # You may obtain a copy of the License at
+            #
+            #     http://www.apache.org/licenses/LICENSE-2.0
+            #
+            # Unless required by applicable law or agreed to in writing, software
+            # distributed under the License is distributed on an "AS IS" BASIS,
+            # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            # See the License for the specific language governing permissions and
+            # limitations under the License.
+
+            # This script is for master and node instance health monitoring, which is
+            # packed in kube-manifest tarball. It is executed through a systemd service
+            # in cluster/gce/gci/<master/node>.yaml. The env variables come from an env
+            # file provided by the systemd service.
+
+            # This script is a slightly adjusted version of
+            # https://github.com/kubernetes/kubernetes/blob/e1a1aa211224fcd9b213420b80b2ae680669683d/cluster/gce/gci/health-monitor.sh
+            # Adjustments are:
+            # * Kubelet health port is 10248 not 10255
+            # * Removal of all all references to the KUBE_ENV file
+
+            set -o nounset
+            set -o pipefail
+
+            # We simply kill the process when there is a failure. Another systemd service will
+            # automatically restart the process.
+            function container_runtime_monitoring() {
+              local -r max_attempts=5
+              local attempt=1
+              local -r container_runtime_name="${CONTAINER_RUNTIME_NAME:-docker}"
+              # We still need to use 'docker ps' when container runtime is "docker". This is because
+              # dockershim is still part of kubelet today. When kubelet is down, crictl pods
+              # will also fail, and docker will be killed. This is undesirable especially when
+              # docker live restore is disabled.
+              local healthcheck_command="docker ps"
+              if [[ "${CONTAINER_RUNTIME:-docker}" != "docker" ]]; then
+                healthcheck_command="crictl pods"
+              fi
+              # Container runtime startup takes time. Make initial attempts before starting
+              # killing the container runtime.
+              until timeout 60 ${healthcheck_command} > /dev/null; do
+                if ((attempt == max_attempts)); then
+                  echo "Max attempt ${max_attempts} reached! Proceeding to monitor container runtime healthiness."
+                  break
+                fi
+                echo "$attempt initial attempt \"${healthcheck_command}\"! Trying again in $attempt seconds..."
+                sleep "$((2 ** attempt++))"
+              done
+              while true; do
+                if ! timeout 60 ${healthcheck_command} > /dev/null; then
+                  echo "Container runtime ${container_runtime_name} failed!"
+                  if [[ "$container_runtime_name" == "docker" ]]; then
+                    # Dump stack of docker daemon for investigation.
+                    # Log file name looks like goroutine-stacks-TIMESTAMP and will be saved to
+                    # the exec root directory, which is /var/run/docker/ on Ubuntu and COS.
+                    pkill -SIGUSR1 dockerd
+                  fi
+                  systemctl kill --kill-who=main "${container_runtime_name}"
+                  # Wait for a while, as we don't want to kill it again before it is really up.
+                  sleep 120
+                else
+                  sleep "${SLEEP_SECONDS}"
+                fi
+              done
+            }
+
+            function kubelet_monitoring() {
+              echo "Wait for 2 minutes for kubelet to be functional"
+              # TODO(andyzheng0831): replace it with a more reliable method if possible.
+              sleep 120
+              local -r max_seconds=10
+              local output=""
+              while true; do
+                local failed=false
+
+                if journalctl -u kubelet -n 1 | grep -q "use of closed network connection"; then
+                  failed=true
+                  echo "Kubelet stopped posting node status. Restarting"
+                elif ! output=$(curl -m "${max_seconds}" -f -s -S http://127.0.0.1:10248/healthz 2>&1); then
+                  failed=true
+                  # Print the response and/or errors.
+                  echo "$output"
+                fi
+
+                if [[ "$failed" == "true" ]]; then
+                  echo "Kubelet is unhealthy!"
+                  systemctl kill kubelet
+                  # Wait for a while, as we don't want to kill it again before it is really up.
+                  sleep 60
+                else
+                  sleep "${SLEEP_SECONDS}"
+                fi
+              done
+            }
+
+            ############## Main Function ################
+            if [[ "$#" -ne 1 ]]; then
+              echo "Usage: health-monitor.sh <container-runtime/kubelet>"
+              exit 1
+            fi
+
+            SLEEP_SECONDS=10
+            component=$1
+            echo "Start kubernetes health monitoring for ${component}"
+            if [[ "${component}" == "container-runtime" ]]; then
+              container_runtime_monitoring
+            elif [[ "${component}" == "kubelet" ]]; then
+              kubelet_monitoring
+            else
+              echo "Health monitoring for component ${component} is not supported!"
+            fi
+
     - path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
       content:
         inline:
@@ -270,11 +391,11 @@ spec:
 
             setenforce 0 || true
 
-            {{- /* As we added some modules and don't want to reboot, restart the service */}}
+            {{- /* As we added some modules and don't want to reboot, restart the service */ }}
             systemctl restart systemd-modules-load.service
             sysctl --system
 
-            {{- /* Make sure we always disable swap - Otherwise the kubelet won't start'. */}}
+            {{- /* Make sure we always disable swap - Otherwise the kubelet won't start'. */ }}
             sed -i.orig '/.*swap.*/d' /etc/fstab
             swapoff -a
 
@@ -352,7 +473,7 @@ spec:
               {{- if .ExternalCloudProvider }}
               --cloud-provider=external \
               {{- else if .InTreeCCMAvailable }}
-              --cloud-provider={{- .CloudProviderName}} \
+              --cloud-provider={{- .CloudProviderName }} \
               --cloud-config=/etc/kubernetes/cloud-config \
               {{- end }}
               {{- if ne .CloudProviderName "aws" }}
@@ -487,7 +608,7 @@ spec:
             - "{{ . }}"
             {{- end }}
             clusterDomain: cluster.local
-            {{- /* containerLogMaxSize and containerLogMaxFiles have no effect for docker  */}}
+            {{- /* containerLogMaxSize and containerLogMaxFiles have no effect for docker  */ }}
             {{- if ne .ContainerRuntime "docker" }}
             {{- if .ContainerLogMaxSize }}
             containerLogMaxSize: {{ .ContainerLogMaxSize }}

--- a/deploy/osps/default/osp-centos.yaml
+++ b/deploy/osps/default/osp-centos.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "centos"
   osVersion: "7.7"
-  version: "v0.1.1"
+  version: "v0.1.2"
   supportedCloudProviders:
     - name: "aws"
     - name: "azure"
@@ -33,13 +33,19 @@ spec:
   supportedContainerRuntimes:
     - name: containerd
       files:
+        - path: "/etc/crictl.yaml"
+          content:
+            inline:
+              data: |
+                runtime-endpoint: unix:///run/containerd/containerd.sock
+
         - path: "/etc/containerd/config.toml"
-          permissions: 0644
+          permissions: 0600
           content:
             inline:
               encoding: b64
               data: |
-                {{ .ContainerRuntimeConfig}}
+                {{ .ContainerRuntimeConfig }}
       templates:
         containerRuntimeInstallation: |-
           yum install -y yum-utils
@@ -47,19 +53,8 @@ spec:
           {{- /*
               Due to DNF modules we have to do this on docker-ce repo
               More info at: https://bugzilla.redhat.com/show_bug.cgi?id=1756473
-          */}}
+          */ }}
           yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
-
-          cat <<EOF | tee /etc/crictl.yaml
-          runtime-endpoint: unix:///run/containerd/containerd.sock
-          EOF
-
-          mkdir -p /etc/systemd/system/containerd.service.d
-          cat <<EOF | tee /etc/systemd/system/containerd.service.d/environment.conf
-          [Service]
-          Restart=always
-          EnvironmentFile=-/etc/environment
-          EOF
 
           yum install -y containerd.io-1.4* yum-plugin-versionlock
           yum versionlock add containerd.io
@@ -75,20 +70,12 @@ spec:
             inline:
               encoding: b64
               data: |-
-                {{ .ContainerRuntimeConfig}}
+                {{ .ContainerRuntimeConfig }}
       templates:
         containerRuntimeInstallation: |-
           yum install -y yum-utils
           yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
           yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
-
-          mkdir -p /etc/systemd/system/containerd.service.d /etc/systemd/system/docker.service.d
-
-          cat <<EOF | tee /etc/systemd/system/containerd.service.d/environment.conf /etc/systemd/system/docker.service.d/environment.conf
-          [Service]
-          Restart=always
-          EnvironmentFile=-/etc/environment
-          EOF
 
           yum install -y \
               docker-ce-cli-19.03* \
@@ -107,10 +94,10 @@ spec:
       usr_local_bin=/usr/local/bin
       cni_bin_dir=/opt/cni/bin
 
-      {{- /* create all the necessary dirs */}}
+      {{- /* create all the necessary dirs */ }}
       mkdir -p /etc/cni/net.d /etc/kubernetes/dynamic-config-dir /etc/kubernetes/manifests "$opt_bin" "$cni_bin_dir"
 
-      {{- /* HOST_ARCH can be defined outside of machine-controller (in kubeone for example) */}}
+      {{- /* HOST_ARCH can be defined outside of machine-controller (in kubeone for example) */ }}
       arch=${HOST_ARCH-}
       if [ -z "$arch" ]
       then
@@ -128,82 +115,77 @@ spec:
       esac
       fi
 
-      {{- /* # CNI variables */}}
+      {{- /* # CNI variables */ }}
       CNI_VERSION="${CNI_VERSION:-v0.8.7}"
       cni_base_url="https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION"
       cni_filename="cni-plugins-linux-$arch-$CNI_VERSION.tgz"
 
-      {{- /* download CNI */}}
+      {{- /* download CNI */ }}
       curl -Lfo "$cni_bin_dir/$cni_filename" "$cni_base_url/$cni_filename"
 
-      {{- /* download CNI checksum */}}
+      {{- /* download CNI checksum */ }}
       cni_sum=$(curl -Lf "$cni_base_url/$cni_filename.sha256")
       cd "$cni_bin_dir"
 
-      {{- /* verify CNI checksum */}}
+      {{- /* verify CNI checksum */ }}
       sha256sum -c <<<"$cni_sum"
 
-      {{- /* unpack CNI */}}
+      {{- /* unpack CNI */ }}
       tar xvf "$cni_filename"
       rm -f "$cni_filename"
       cd -
 
-      {{- /* # cri-tools variables */}}
+      {{- /* # cri-tools variables */ }}
       CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.22.0}"
       cri_tools_base_url="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}"
       cri_tools_filename="crictl-${CRI_TOOLS_RELEASE}-linux-${arch}.tar.gz"
 
-      {{- /* download cri-tools */}}
+      {{- /* download cri-tools */ }}
       curl -Lfo "$opt_bin/$cri_tools_filename" "$cri_tools_base_url/$cri_tools_filename"
 
-      {{- /* download cri-tools checksum */}}
-      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */}}
+      {{- /* download cri-tools checksum */ }}
+      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */ }}
       cri_tools_sum=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256" | sed 's/\*\///')
       cd "$opt_bin"
 
-      {{- /* verify cri-tools checksum */}}
+      {{- /* verify cri-tools checksum */ }}
       sha256sum -c <<<"$cri_tools_sum"
 
-      {{- /* unpack cri-tools and symlink to path so it's available to all users */}}
+      {{- /* unpack cri-tools and symlink to path so it's available to all users */ }}
       tar xvf "$cri_tools_filename"
       rm -f "$cri_tools_filename"
       ln -sf "$opt_bin/crictl" "$usr_local_bin"/crictl || echo "symbolic link is skipped"
       cd -
 
-      {{- /* kubelet */}}
+      {{- /* kubelet */ }}
       KUBE_VERSION="${KUBE_VERSION:-{{ .KubeVersion }}}"
       kube_dir="$opt_bin/kubernetes-$KUBE_VERSION"
       kube_base_url="https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$arch"
       kube_sum_file="$kube_dir/sha256"
 
-      {{- /* create versioned kube dir */}}
+      {{- /* create versioned kube dir */ }}
       mkdir -p "$kube_dir"
       : >"$kube_sum_file"
 
       for bin in kubelet kubeadm kubectl; do
-          {{- /* download kube binary */}}
+          {{- /* download kube binary */ }}
           curl -Lfo "$kube_dir/$bin" "$kube_base_url/$bin"
           chmod +x "$kube_dir/$bin"
 
-          {{- /* download kube binary checksum */}}
+          {{- /* download kube binary checksum */ }}
           sum=$(curl -Lf "$kube_base_url/$bin.sha256")
 
-          {{- /* save kube binary checksum */}}
+          {{- /* save kube binary checksum */ }}
           echo "$sum  $kube_dir/$bin" >>"$kube_sum_file"
       done
 
-      {{- /* check kube binaries checksum */}}
+      {{- /* check kube binaries checksum */ }}
       sha256sum -c "$kube_sum_file"
 
       for bin in kubelet kubeadm kubectl; do
-          {{- /* link kube binaries from verioned dir to $opt_bin */}}
+          {{- /* link kube binaries from verioned dir to $opt_bin */ }}
           ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
       done
-
-      if [[ ! -x /opt/bin/health-monitor.sh ]]; then
-          curl -Lfo /opt/bin/health-monitor.sh https://raw.githubusercontent.com/kubermatic/machine-controller/7967a0af2b75f29ad2ab227eeaa26ea7b0f2fbde/pkg/userdata/scripts/health-monitor.sh
-          chmod +x /opt/bin/health-monitor.sh
-      fi
 
     configureProxyScript: |-
       {{- if .HTTPProxy }}
@@ -218,6 +200,159 @@ spec:
       {{- end }}
 
   files:
+    - path: /etc/environment
+      content:
+        inline:
+          data: |
+            {{- if .HTTPProxy }}
+            HTTP_PROXY={{ .HTTPProxy }}
+            http_proxy={{ .HTTPProxy }}
+            HTTPS_PROXY={{ .HTTPProxy }}
+            https_proxy={{ .HTTPProxy }}
+            NO_PROXY={{ .NoProxy }}
+            no_proxy={{ .NoProxy }}
+            {{- end }}
+
+    - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+      content:
+        inline:
+          data: |
+            [Service]
+            Restart=always
+            EnvironmentFile=-/etc/environment
+
+    - path: "/etc/systemd/system/docker.service.d/environment.conf"
+      content:
+        inline:
+          data: |
+            [Service]
+            Restart=always
+            EnvironmentFile=-/etc/environment
+
+    - path: "/opt/bin/health-monitor.sh"
+      permissions: 0755
+      content:
+        inline:
+          encoding: b64
+          data: |
+            #!/usr/bin/env bash
+
+            # Copyright 2016 The Kubernetes Authors.
+            #
+            # Licensed under the Apache License, Version 2.0 (the "License");
+            # you may not use this file except in compliance with the License.
+            # You may obtain a copy of the License at
+            #
+            #     http://www.apache.org/licenses/LICENSE-2.0
+            #
+            # Unless required by applicable law or agreed to in writing, software
+            # distributed under the License is distributed on an "AS IS" BASIS,
+            # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            # See the License for the specific language governing permissions and
+            # limitations under the License.
+
+            # This script is for master and node instance health monitoring, which is
+            # packed in kube-manifest tarball. It is executed through a systemd service
+            # in cluster/gce/gci/<master/node>.yaml. The env variables come from an env
+            # file provided by the systemd service.
+
+            # This script is a slightly adjusted version of
+            # https://github.com/kubernetes/kubernetes/blob/e1a1aa211224fcd9b213420b80b2ae680669683d/cluster/gce/gci/health-monitor.sh
+            # Adjustments are:
+            # * Kubelet health port is 10248 not 10255
+            # * Removal of all all references to the KUBE_ENV file
+
+            set -o nounset
+            set -o pipefail
+
+            # We simply kill the process when there is a failure. Another systemd service will
+            # automatically restart the process.
+            function container_runtime_monitoring() {
+              local -r max_attempts=5
+              local attempt=1
+              local -r container_runtime_name="${CONTAINER_RUNTIME_NAME:-docker}"
+              # We still need to use 'docker ps' when container runtime is "docker". This is because
+              # dockershim is still part of kubelet today. When kubelet is down, crictl pods
+              # will also fail, and docker will be killed. This is undesirable especially when
+              # docker live restore is disabled.
+              local healthcheck_command="docker ps"
+              if [[ "${CONTAINER_RUNTIME:-docker}" != "docker" ]]; then
+                healthcheck_command="crictl pods"
+              fi
+              # Container runtime startup takes time. Make initial attempts before starting
+              # killing the container runtime.
+              until timeout 60 ${healthcheck_command} > /dev/null; do
+                if ((attempt == max_attempts)); then
+                  echo "Max attempt ${max_attempts} reached! Proceeding to monitor container runtime healthiness."
+                  break
+                fi
+                echo "$attempt initial attempt \"${healthcheck_command}\"! Trying again in $attempt seconds..."
+                sleep "$((2 ** attempt++))"
+              done
+              while true; do
+                if ! timeout 60 ${healthcheck_command} > /dev/null; then
+                  echo "Container runtime ${container_runtime_name} failed!"
+                  if [[ "$container_runtime_name" == "docker" ]]; then
+                    # Dump stack of docker daemon for investigation.
+                    # Log file name looks like goroutine-stacks-TIMESTAMP and will be saved to
+                    # the exec root directory, which is /var/run/docker/ on Ubuntu and COS.
+                    pkill -SIGUSR1 dockerd
+                  fi
+                  systemctl kill --kill-who=main "${container_runtime_name}"
+                  # Wait for a while, as we don't want to kill it again before it is really up.
+                  sleep 120
+                else
+                  sleep "${SLEEP_SECONDS}"
+                fi
+              done
+            }
+
+            function kubelet_monitoring() {
+              echo "Wait for 2 minutes for kubelet to be functional"
+              # TODO(andyzheng0831): replace it with a more reliable method if possible.
+              sleep 120
+              local -r max_seconds=10
+              local output=""
+              while true; do
+                local failed=false
+
+                if journalctl -u kubelet -n 1 | grep -q "use of closed network connection"; then
+                  failed=true
+                  echo "Kubelet stopped posting node status. Restarting"
+                elif ! output=$(curl -m "${max_seconds}" -f -s -S http://127.0.0.1:10248/healthz 2>&1); then
+                  failed=true
+                  # Print the response and/or errors.
+                  echo "$output"
+                fi
+
+                if [[ "$failed" == "true" ]]; then
+                  echo "Kubelet is unhealthy!"
+                  systemctl kill kubelet
+                  # Wait for a while, as we don't want to kill it again before it is really up.
+                  sleep 60
+                else
+                  sleep "${SLEEP_SECONDS}"
+                fi
+              done
+            }
+
+            ############## Main Function ################
+            if [[ "$#" -ne 1 ]]; then
+              echo "Usage: health-monitor.sh <container-runtime/kubelet>"
+              exit 1
+            fi
+
+            SLEEP_SECONDS=10
+            component=$1
+            echo "Start kubernetes health monitoring for ${component}"
+            if [[ "${component}" == "container-runtime" ]]; then
+              container_runtime_monitoring
+            elif [[ "${component}" == "kubelet" ]]; then
+              kubelet_monitoring
+            else
+              echo "Health monitoring for component ${component} is not supported!"
+            fi
+
     - path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
       content:
         inline:
@@ -287,11 +422,11 @@ spec:
 
             setenforce 0 || true
 
-            {{- /* As we added some modules and don't want to reboot, restart the service */}}
+            {{- /* As we added some modules and don't want to reboot, restart the service */ }}
             systemctl restart systemd-modules-load.service
             sysctl --system
 
-            {{- /* Make sure we always disable swap - Otherwise the kubelet won't start'. */}}
+            {{- /* Make sure we always disable swap - Otherwise the kubelet won't start'. */ }}
             sed -i.orig '/.*swap.*/d' /etc/fstab
             swapoff -a
 
@@ -314,16 +449,16 @@ spec:
               {{- end }}
               ipvsadm
 
-            {{- /* iscsid service is required on Nutanix machines for CSI driver to attach volumes. */}}
+            {{- /* iscsid service is required on Nutanix machines for CSI driver to attach volumes. */ }}
             {{- if eq .CloudProviderName "nutanix" }}
             systemctl enable --now iscsid
             {{ end }}
 
-            {{- template "configureProxyScript" }}
-
             {{- template "containerRuntimeInstallation" }}
 
             {{- template "safeDownloadBinariesScript" }}
+
+            {{- template "configureProxyScript" }}
 
             mkdir -p /etc/systemd/system/kubelet.service.d/
             # set kubelet nodeip environment variable
@@ -381,7 +516,7 @@ spec:
               {{- if .ExternalCloudProvider }}
               --cloud-provider=external \
               {{- else if .InTreeCCMAvailable }}
-              --cloud-provider={{- .CloudProviderName}} \
+              --cloud-provider={{- .CloudProviderName }} \
               --cloud-config=/etc/kubernetes/cloud-config \
               {{- end }}
               {{- if ne .CloudProviderName "aws" }}
@@ -516,7 +651,7 @@ spec:
             - "{{ . }}"
             {{- end }}
             clusterDomain: cluster.local
-            {{- /* containerLogMaxSize and containerLogMaxFiles have no effect for docker  */}}
+            {{- /* containerLogMaxSize and containerLogMaxFiles have no effect for docker  */ }}
             {{- if ne .ContainerRuntime "docker" }}
             {{- if .ContainerLogMaxSize }}
             containerLogMaxSize: {{ .ContainerLogMaxSize }}

--- a/deploy/osps/default/osp-centos.yaml
+++ b/deploy/osps/default/osp-centos.yaml
@@ -33,6 +33,14 @@ spec:
   supportedContainerRuntimes:
     - name: containerd
       files:
+        - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
         - path: "/etc/crictl.yaml"
           content:
             inline:
@@ -64,6 +72,22 @@ spec:
 
     - name: docker
       files:
+        - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
+        - path: "/etc/systemd/system/docker.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
         - path: /etc/docker/daemon.json
           permissions: 0644
           content:
@@ -200,35 +224,6 @@ spec:
       {{- end }}
 
   files:
-    - path: /etc/environment
-      content:
-        inline:
-          data: |
-            {{- if .HTTPProxy }}
-            HTTP_PROXY={{ .HTTPProxy }}
-            http_proxy={{ .HTTPProxy }}
-            HTTPS_PROXY={{ .HTTPProxy }}
-            https_proxy={{ .HTTPProxy }}
-            NO_PROXY={{ .NoProxy }}
-            no_proxy={{ .NoProxy }}
-            {{- end }}
-
-    - path: "/etc/systemd/system/containerd.service.d/environment.conf"
-      content:
-        inline:
-          data: |
-            [Service]
-            Restart=always
-            EnvironmentFile=-/etc/environment
-
-    - path: "/etc/systemd/system/docker.service.d/environment.conf"
-      content:
-        inline:
-          data: |
-            [Service]
-            Restart=always
-            EnvironmentFile=-/etc/environment
-
     - path: "/opt/bin/health-monitor.sh"
       permissions: 0755
       content:

--- a/deploy/osps/default/osp-centos8.yaml
+++ b/deploy/osps/default/osp-centos8.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "centos"
   osVersion: "8"
-  version: "v0.1.1"
+  version: "v0.1.2"
   supportedCloudProviders:
     - name: "aws"
     - name: "azure"
@@ -33,13 +33,19 @@ spec:
   supportedContainerRuntimes:
     - name: containerd
       files:
+        - path: "/etc/crictl.yaml"
+          content:
+            inline:
+              data: |
+                runtime-endpoint: unix:///run/containerd/containerd.sock
+
         - path: "/etc/containerd/config.toml"
-          permissions: 0644
+          permissions: 0600
           content:
             inline:
               encoding: b64
               data: |
-                {{ .ContainerRuntimeConfig}}
+                {{ .ContainerRuntimeConfig }}
       templates:
         containerRuntimeInstallation: |-
           yum install -y yum-utils
@@ -47,19 +53,8 @@ spec:
           {{- /*
               Due to DNF modules we have to do this on docker-ce repo
               More info at: https://bugzilla.redhat.com/show_bug.cgi?id=1756473
-          */}}
+          */ }}
           yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
-
-          cat <<EOF | tee /etc/crictl.yaml
-          runtime-endpoint: unix:///run/containerd/containerd.sock
-          EOF
-
-          mkdir -p /etc/systemd/system/containerd.service.d
-          cat <<EOF | tee /etc/systemd/system/containerd.service.d/environment.conf
-          [Service]
-          Restart=always
-          EnvironmentFile=-/etc/environment
-          EOF
 
           yum install -y containerd.io-1.4* yum-plugin-versionlock
           yum versionlock add containerd.io
@@ -75,20 +70,12 @@ spec:
             inline:
               encoding: b64
               data: |-
-                {{ .ContainerRuntimeConfig}}
+                {{ .ContainerRuntimeConfig }}
       templates:
         containerRuntimeInstallation: |-
           yum install -y yum-utils
           yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
           yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
-
-          mkdir -p /etc/systemd/system/containerd.service.d /etc/systemd/system/docker.service.d
-
-          cat <<EOF | tee /etc/systemd/system/containerd.service.d/environment.conf /etc/systemd/system/docker.service.d/environment.conf
-          [Service]
-          Restart=always
-          EnvironmentFile=-/etc/environment
-          EOF
 
           yum install -y \
               docker-ce-cli-19.03* \
@@ -107,10 +94,10 @@ spec:
       usr_local_bin=/usr/local/bin
       cni_bin_dir=/opt/cni/bin
 
-      {{- /* create all the necessary dirs */}}
+      {{- /* create all the necessary dirs */ }}
       mkdir -p /etc/cni/net.d /etc/kubernetes/dynamic-config-dir /etc/kubernetes/manifests "$opt_bin" "$cni_bin_dir"
 
-      {{- /* HOST_ARCH can be defined outside of machine-controller (in kubeone for example) */}}
+      {{- /* HOST_ARCH can be defined outside of machine-controller (in kubeone for example) */ }}
       arch=${HOST_ARCH-}
       if [ -z "$arch" ]
       then
@@ -128,82 +115,77 @@ spec:
       esac
       fi
 
-      {{- /* # CNI variables */}}
+      {{- /* # CNI variables */ }}
       CNI_VERSION="${CNI_VERSION:-v0.8.7}"
       cni_base_url="https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION"
       cni_filename="cni-plugins-linux-$arch-$CNI_VERSION.tgz"
 
-      {{- /* download CNI */}}
+      {{- /* download CNI */ }}
       curl -Lfo "$cni_bin_dir/$cni_filename" "$cni_base_url/$cni_filename"
 
-      {{- /* download CNI checksum */}}
+      {{- /* download CNI checksum */ }}
       cni_sum=$(curl -Lf "$cni_base_url/$cni_filename.sha256")
       cd "$cni_bin_dir"
 
-      {{- /* verify CNI checksum */}}
+      {{- /* verify CNI checksum */ }}
       sha256sum -c <<<"$cni_sum"
 
-      {{- /* unpack CNI */}}
+      {{- /* unpack CNI */ }}
       tar xvf "$cni_filename"
       rm -f "$cni_filename"
       cd -
 
-      {{- /* # cri-tools variables */}}
+      {{- /* # cri-tools variables */ }}
       CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.22.0}"
       cri_tools_base_url="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}"
       cri_tools_filename="crictl-${CRI_TOOLS_RELEASE}-linux-${arch}.tar.gz"
 
-      {{- /* download cri-tools */}}
+      {{- /* download cri-tools */ }}
       curl -Lfo "$opt_bin/$cri_tools_filename" "$cri_tools_base_url/$cri_tools_filename"
 
-      {{- /* download cri-tools checksum */}}
-      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */}}
+      {{- /* download cri-tools checksum */ }}
+      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */ }}
       cri_tools_sum=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256" | sed 's/\*\///')
       cd "$opt_bin"
 
-      {{- /* verify cri-tools checksum */}}
+      {{- /* verify cri-tools checksum */ }}
       sha256sum -c <<<"$cri_tools_sum"
 
-      {{- /* unpack cri-tools and symlink to path so it's available to all users */}}
+      {{- /* unpack cri-tools and symlink to path so it's available to all users */ }}
       tar xvf "$cri_tools_filename"
       rm -f "$cri_tools_filename"
       ln -sf "$opt_bin/crictl" "$usr_local_bin"/crictl || echo "symbolic link is skipped"
       cd -
 
-      {{- /* kubelet */}}
+      {{- /* kubelet */ }}
       KUBE_VERSION="${KUBE_VERSION:-{{ .KubeVersion }}}"
       kube_dir="$opt_bin/kubernetes-$KUBE_VERSION"
       kube_base_url="https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$arch"
       kube_sum_file="$kube_dir/sha256"
 
-      {{- /* create versioned kube dir */}}
+      {{- /* create versioned kube dir */ }}
       mkdir -p "$kube_dir"
       : >"$kube_sum_file"
 
       for bin in kubelet kubeadm kubectl; do
-          {{- /* download kube binary */}}
+          {{- /* download kube binary */ }}
           curl -Lfo "$kube_dir/$bin" "$kube_base_url/$bin"
           chmod +x "$kube_dir/$bin"
 
-          {{- /* download kube binary checksum */}}
+          {{- /* download kube binary checksum */ }}
           sum=$(curl -Lf "$kube_base_url/$bin.sha256")
 
-          {{- /* save kube binary checksum */}}
+          {{- /* save kube binary checksum */ }}
           echo "$sum  $kube_dir/$bin" >>"$kube_sum_file"
       done
 
-      {{- /* check kube binaries checksum */}}
+      {{- /* check kube binaries checksum */ }}
       sha256sum -c "$kube_sum_file"
 
       for bin in kubelet kubeadm kubectl; do
-          {{- /* link kube binaries from verioned dir to $opt_bin */}}
+          {{- /* link kube binaries from verioned dir to $opt_bin */ }}
           ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
       done
-
-      if [[ ! -x /opt/bin/health-monitor.sh ]]; then
-          curl -Lfo /opt/bin/health-monitor.sh https://raw.githubusercontent.com/kubermatic/machine-controller/7967a0af2b75f29ad2ab227eeaa26ea7b0f2fbde/pkg/userdata/scripts/health-monitor.sh
-          chmod +x /opt/bin/health-monitor.sh
-      fi
 
     configureProxyScript: |-
       {{- if .HTTPProxy }}
@@ -218,6 +200,159 @@ spec:
       {{- end }}
 
   files:
+    - path: /etc/environment
+      content:
+        inline:
+          data: |
+            {{- if .HTTPProxy }}
+            HTTP_PROXY={{ .HTTPProxy }}
+            http_proxy={{ .HTTPProxy }}
+            HTTPS_PROXY={{ .HTTPProxy }}
+            https_proxy={{ .HTTPProxy }}
+            NO_PROXY={{ .NoProxy }}
+            no_proxy={{ .NoProxy }}
+            {{- end }}
+
+    - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+      content:
+        inline:
+          data: |
+            [Service]
+            Restart=always
+            EnvironmentFile=-/etc/environment
+
+    - path: "/etc/systemd/system/docker.service.d/environment.conf"
+      content:
+        inline:
+          data: |
+            [Service]
+            Restart=always
+            EnvironmentFile=-/etc/environment
+
+    - path: "/opt/bin/health-monitor.sh"
+      permissions: 0755
+      content:
+        inline:
+          encoding: b64
+          data: |
+            #!/usr/bin/env bash
+
+            # Copyright 2016 The Kubernetes Authors.
+            #
+            # Licensed under the Apache License, Version 2.0 (the "License");
+            # you may not use this file except in compliance with the License.
+            # You may obtain a copy of the License at
+            #
+            #     http://www.apache.org/licenses/LICENSE-2.0
+            #
+            # Unless required by applicable law or agreed to in writing, software
+            # distributed under the License is distributed on an "AS IS" BASIS,
+            # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            # See the License for the specific language governing permissions and
+            # limitations under the License.
+
+            # This script is for master and node instance health monitoring, which is
+            # packed in kube-manifest tarball. It is executed through a systemd service
+            # in cluster/gce/gci/<master/node>.yaml. The env variables come from an env
+            # file provided by the systemd service.
+
+            # This script is a slightly adjusted version of
+            # https://github.com/kubernetes/kubernetes/blob/e1a1aa211224fcd9b213420b80b2ae680669683d/cluster/gce/gci/health-monitor.sh
+            # Adjustments are:
+            # * Kubelet health port is 10248 not 10255
+            # * Removal of all all references to the KUBE_ENV file
+
+            set -o nounset
+            set -o pipefail
+
+            # We simply kill the process when there is a failure. Another systemd service will
+            # automatically restart the process.
+            function container_runtime_monitoring() {
+              local -r max_attempts=5
+              local attempt=1
+              local -r container_runtime_name="${CONTAINER_RUNTIME_NAME:-docker}"
+              # We still need to use 'docker ps' when container runtime is "docker". This is because
+              # dockershim is still part of kubelet today. When kubelet is down, crictl pods
+              # will also fail, and docker will be killed. This is undesirable especially when
+              # docker live restore is disabled.
+              local healthcheck_command="docker ps"
+              if [[ "${CONTAINER_RUNTIME:-docker}" != "docker" ]]; then
+                healthcheck_command="crictl pods"
+              fi
+              # Container runtime startup takes time. Make initial attempts before starting
+              # killing the container runtime.
+              until timeout 60 ${healthcheck_command} > /dev/null; do
+                if ((attempt == max_attempts)); then
+                  echo "Max attempt ${max_attempts} reached! Proceeding to monitor container runtime healthiness."
+                  break
+                fi
+                echo "$attempt initial attempt \"${healthcheck_command}\"! Trying again in $attempt seconds..."
+                sleep "$((2 ** attempt++))"
+              done
+              while true; do
+                if ! timeout 60 ${healthcheck_command} > /dev/null; then
+                  echo "Container runtime ${container_runtime_name} failed!"
+                  if [[ "$container_runtime_name" == "docker" ]]; then
+                    # Dump stack of docker daemon for investigation.
+                    # Log file name looks like goroutine-stacks-TIMESTAMP and will be saved to
+                    # the exec root directory, which is /var/run/docker/ on Ubuntu and COS.
+                    pkill -SIGUSR1 dockerd
+                  fi
+                  systemctl kill --kill-who=main "${container_runtime_name}"
+                  # Wait for a while, as we don't want to kill it again before it is really up.
+                  sleep 120
+                else
+                  sleep "${SLEEP_SECONDS}"
+                fi
+              done
+            }
+
+            function kubelet_monitoring() {
+              echo "Wait for 2 minutes for kubelet to be functional"
+              # TODO(andyzheng0831): replace it with a more reliable method if possible.
+              sleep 120
+              local -r max_seconds=10
+              local output=""
+              while true; do
+                local failed=false
+
+                if journalctl -u kubelet -n 1 | grep -q "use of closed network connection"; then
+                  failed=true
+                  echo "Kubelet stopped posting node status. Restarting"
+                elif ! output=$(curl -m "${max_seconds}" -f -s -S http://127.0.0.1:10248/healthz 2>&1); then
+                  failed=true
+                  # Print the response and/or errors.
+                  echo "$output"
+                fi
+
+                if [[ "$failed" == "true" ]]; then
+                  echo "Kubelet is unhealthy!"
+                  systemctl kill kubelet
+                  # Wait for a while, as we don't want to kill it again before it is really up.
+                  sleep 60
+                else
+                  sleep "${SLEEP_SECONDS}"
+                fi
+              done
+            }
+
+            ############## Main Function ################
+            if [[ "$#" -ne 1 ]]; then
+              echo "Usage: health-monitor.sh <container-runtime/kubelet>"
+              exit 1
+            fi
+
+            SLEEP_SECONDS=10
+            component=$1
+            echo "Start kubernetes health monitoring for ${component}"
+            if [[ "${component}" == "container-runtime" ]]; then
+              container_runtime_monitoring
+            elif [[ "${component}" == "kubelet" ]]; then
+              kubelet_monitoring
+            else
+              echo "Health monitoring for component ${component} is not supported!"
+            fi
+
     - path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
       content:
         inline:
@@ -287,15 +422,15 @@ spec:
 
             setenforce 0 || true
 
-            {{- /* As we added some modules and don't want to reboot, restart the service */}}
+            {{- /* As we added some modules and don't want to reboot, restart the service */ }}
             systemctl restart systemd-modules-load.service
             sysctl --system
 
-            {{- /* Make sure we always disable swap - Otherwise the kubelet won't start'. */}}
+            {{- /* Make sure we always disable swap - Otherwise the kubelet won't start'. */ }}
             sed -i.orig '/.*swap.*/d' /etc/fstab
             swapoff -a
 
-            {{- /* CentOS 8 has reached EOL and all packages were moved to vault.centos.org -- https://www.centos.org/centos-linux-eol/ */}}
+            {{- /* CentOS 8 has reached EOL and all packages were moved to vault.centos.org -- https://www.centos.org/centos-linux-eol/ */ }}
             sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
             sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
@@ -318,16 +453,16 @@ spec:
               {{- end }}
               ipvsadm
 
-            {{- /* iscsid service is required on Nutanix machines for CSI driver to attach volumes. */}}
+            {{- /* iscsid service is required on Nutanix machines for CSI driver to attach volumes. */ }}
             {{- if eq .CloudProviderName "nutanix" }}
             systemctl enable --now iscsid
             {{ end }}
 
-            {{- template "configureProxyScript" }}
-
             {{- template "containerRuntimeInstallation" }}
 
             {{- template "safeDownloadBinariesScript" }}
+
+            {{- template "configureProxyScript" }}
 
             mkdir -p /etc/systemd/system/kubelet.service.d/
             # set kubelet nodeip environment variable
@@ -385,7 +520,7 @@ spec:
               {{- if .ExternalCloudProvider }}
               --cloud-provider=external \
               {{- else if .InTreeCCMAvailable }}
-              --cloud-provider={{- .CloudProviderName}} \
+              --cloud-provider={{- .CloudProviderName }} \
               --cloud-config=/etc/kubernetes/cloud-config \
               {{- end }}
               {{- if ne .CloudProviderName "aws" }}
@@ -520,7 +655,7 @@ spec:
             - "{{ . }}"
             {{- end }}
             clusterDomain: cluster.local
-            {{- /* containerLogMaxSize and containerLogMaxFiles have no effect for docker  */}}
+            {{- /* containerLogMaxSize and containerLogMaxFiles have no effect for docker  */ }}
             {{- if ne .ContainerRuntime "docker" }}
             {{- if .ContainerLogMaxSize }}
             containerLogMaxSize: {{ .ContainerLogMaxSize }}

--- a/deploy/osps/default/osp-centos8.yaml
+++ b/deploy/osps/default/osp-centos8.yaml
@@ -39,6 +39,14 @@ spec:
               data: |
                 runtime-endpoint: unix:///run/containerd/containerd.sock
 
+        - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
         - path: "/etc/containerd/config.toml"
           permissions: 0600
           content:
@@ -64,6 +72,22 @@ spec:
 
     - name: docker
       files:
+        - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
+        - path: "/etc/systemd/system/docker.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
         - path: /etc/docker/daemon.json
           permissions: 0644
           content:
@@ -200,35 +224,6 @@ spec:
       {{- end }}
 
   files:
-    - path: /etc/environment
-      content:
-        inline:
-          data: |
-            {{- if .HTTPProxy }}
-            HTTP_PROXY={{ .HTTPProxy }}
-            http_proxy={{ .HTTPProxy }}
-            HTTPS_PROXY={{ .HTTPProxy }}
-            https_proxy={{ .HTTPProxy }}
-            NO_PROXY={{ .NoProxy }}
-            no_proxy={{ .NoProxy }}
-            {{- end }}
-
-    - path: "/etc/systemd/system/containerd.service.d/environment.conf"
-      content:
-        inline:
-          data: |
-            [Service]
-            Restart=always
-            EnvironmentFile=-/etc/environment
-
-    - path: "/etc/systemd/system/docker.service.d/environment.conf"
-      content:
-        inline:
-          data: |
-            [Service]
-            Restart=always
-            EnvironmentFile=-/etc/environment
-
     - path: "/opt/bin/health-monitor.sh"
       permissions: 0755
       content:

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -21,7 +21,7 @@ spec:
   osName: flatcar
   ## Flatcar Stable (09/11/2021)
   osVersion: "2983.2.0"
-  version: "v0.1.1"
+  version: "v0.1.2"
   supportedCloudProviders:
     - name: aws
     - name: azure
@@ -32,22 +32,22 @@ spec:
     - name: containerd
       files:
         - path: /etc/containerd/config.toml
-          permissions: 0644
+          permissions: 0600
           content:
             inline:
               data: |
-                {{ .ContainerRuntimeConfig}}
+                {{ .ContainerRuntimeConfig }}
+
         - path: /etc/systemd/system/containerd.service.d/10-custom.conf
           content:
             inline:
               data: |
                 [Service]
-                Restart=always
-                EnvironmentFile=-/etc/environment
                 EnvironmentFile=/run/metadata/torcx
                 Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
                 ExecStart=
                 ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/containerd --config ${CONTAINERD_CONFIG}
+
         - path: /etc/crictl.yaml
           content:
             inline:
@@ -61,14 +61,7 @@ spec:
           content:
             inline:
               data: |-
-                {{ .ContainerRuntimeConfig}}
-        - path: /etc/systemd/system/docker.service.d/10-custom.conf
-          permissions: 0644
-          content:
-            inline:
-              data: |-
-                [Service]
-                EnvironmentFile=-/etc/environment
+                {{ .ContainerRuntimeConfig }}
 
   templates:
     safeDownloadBinariesScript: |-
@@ -77,10 +70,10 @@ spec:
       usr_local_bin=/usr/local/bin
       cni_bin_dir=/opt/cni/bin
 
-      {{- /* create all the necessary dirs */}}
+      {{- /* create all the necessary dirs */ }}
       mkdir -p /etc/cni/net.d /etc/kubernetes/dynamic-config-dir /etc/kubernetes/manifests "$opt_bin" "$cni_bin_dir"
 
-      {{- /* HOST_ARCH can be defined outside of machine-controller (in kubeone for example) */}}
+      {{- /* HOST_ARCH can be defined outside of machine-controller (in kubeone for example) */ }}
       arch=${HOST_ARCH-}
       if [ -z "$arch" ]
       then
@@ -98,101 +91,77 @@ spec:
       esac
       fi
 
-      {{- /* # CNI variables */}}
+      {{- /* # CNI variables */ }}
       CNI_VERSION="${CNI_VERSION:-v0.8.7}"
       cni_base_url="https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION"
       cni_filename="cni-plugins-linux-$arch-$CNI_VERSION.tgz"
 
-      {{- /* download CNI */}}
+      {{- /* download CNI */ }}
       curl -Lfo "$cni_bin_dir/$cni_filename" "$cni_base_url/$cni_filename"
 
-      {{- /* download CNI checksum */}}
+      {{- /* download CNI checksum */ }}
       cni_sum=$(curl -Lf "$cni_base_url/$cni_filename.sha256")
       cd "$cni_bin_dir"
 
-      {{- /* verify CNI checksum */}}
+      {{- /* verify CNI checksum */ }}
       sha256sum -c <<<"$cni_sum"
 
-      {{- /* unpack CNI */}}
+      {{- /* unpack CNI */ }}
       tar xvf "$cni_filename"
       rm -f "$cni_filename"
       cd -
 
-      {{- /* # cri-tools variables */}}
+      {{- /* # cri-tools variables */ }}
       CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.22.0}"
       cri_tools_base_url="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}"
       cri_tools_filename="crictl-${CRI_TOOLS_RELEASE}-linux-${arch}.tar.gz"
 
-      {{- /* download cri-tools */}}
+      {{- /* download cri-tools */ }}
       curl -Lfo "$opt_bin/$cri_tools_filename" "$cri_tools_base_url/$cri_tools_filename"
 
-      {{- /* download cri-tools checksum */}}
-      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */}}
+      {{- /* download cri-tools checksum */ }}
+      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */ }}
       cri_tools_sum=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256" | sed 's/\*\///')
       cd "$opt_bin"
 
-      {{- /* verify cri-tools checksum */}}
+      {{- /* verify cri-tools checksum */ }}
       sha256sum -c <<<"$cri_tools_sum"
 
-      {{- /* unpack cri-tools and symlink to path so it's available to all users */}}
+      {{- /* unpack cri-tools and symlink to path so it's available to all users */ }}
       tar xvf "$cri_tools_filename"
       rm -f "$cri_tools_filename"
       ln -sf "$opt_bin/crictl" "$usr_local_bin"/crictl || echo "symbolic link is skipped"
       cd -
 
-      {{- /* kubelet */}}
+      {{- /* kubelet */ }}
       KUBE_VERSION="${KUBE_VERSION:-{{ .KubeVersion }}}"
       kube_dir="$opt_bin/kubernetes-$KUBE_VERSION"
       kube_base_url="https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$arch"
       kube_sum_file="$kube_dir/sha256"
 
-      {{- /* create versioned kube dir */}}
+      {{- /* create versioned kube dir */ }}
       mkdir -p "$kube_dir"
       : >"$kube_sum_file"
 
       for bin in kubelet kubeadm kubectl; do
-          {{- /* download kube binary */}}
+          {{- /* download kube binary */ }}
           curl -Lfo "$kube_dir/$bin" "$kube_base_url/$bin"
           chmod +x "$kube_dir/$bin"
 
-          {{- /* download kube binary checksum */}}
+          {{- /* download kube binary checksum */ }}
           sum=$(curl -Lf "$kube_base_url/$bin.sha256")
 
-          {{- /* save kube binary checksum */}}
+          {{- /* save kube binary checksum */ }}
           echo "$sum  $kube_dir/$bin" >>"$kube_sum_file"
       done
 
-      {{- /* check kube binaries checksum */}}
+      {{- /* check kube binaries checksum */ }}
       sha256sum -c "$kube_sum_file"
 
       for bin in kubelet kubeadm kubectl; do
-          {{- /* link kube binaries from verioned dir to $opt_bin */}}
+          {{- /* link kube binaries from verioned dir to $opt_bin */ }}
           ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
       done
-
-      if [[ ! -x /opt/bin/health-monitor.sh ]]; then
-          curl -Lfo /opt/bin/health-monitor.sh https://raw.githubusercontent.com/kubermatic/machine-controller/7967a0af2b75f29ad2ab227eeaa26ea7b0f2fbde/pkg/userdata/scripts/health-monitor.sh
-          chmod +x /opt/bin/health-monitor.sh
-      fi
-
-    configureStaticNetwork: |-
-      {{- if .NetworkConfig }}
-      mkdir -p /etc/systemd/system/systemd-networkd.service.d/
-      cat << EOF | tee /etc/systemd/system/systemd-networkd.service.d/10-static-network.conf
-      [Match]
-      # Because of difficulty predicting specific NIC names on different cloud providers,
-      # we only support static addressing on VSphere. There should be a single NIC attached
-      # that we will match by name prefix 'en' which denotes ethernet devices.
-      Name=en*
-
-      [Network]
-      DHCP=no
-      Address={{ .NetworkConfig.CIDR }}
-      Gateway={{ .NetworkConfig.Gateway }}
-      {{range .NetworkConfig.DNS.Servers}}DNS={{.}}
-      {{end}}
-      EOF
-      {{- end }}
 
     configureProxyScript: |-
       {{- if .HTTPProxy }}
@@ -256,22 +225,178 @@ spec:
         [Install]
         WantedBy=multi-user.target
 
-    - name: static-network-script.service
-      enable: true
-      content: |
-        [Unit]
-        Description=Setup Static Networking
-        Requires=network-online.target
-        After=network-online.target
-
-        [Service]
-        ExecStart=/opt/bin/configure_static_network.sh
-        RemainAfterExit=yes
-        Type=oneshot
-        [Install]
-        WantedBy=multi-user.target
-
   files:
+    - path: "/opt/bin/health-monitor.sh"
+      permissions: 0755
+      content:
+        inline:
+          data: |
+            #!/usr/bin/env bash
+
+            # Copyright 2016 The Kubernetes Authors.
+            #
+            # Licensed under the Apache License, Version 2.0 (the "License");
+            # you may not use this file except in compliance with the License.
+            # You may obtain a copy of the License at
+            #
+            #     http://www.apache.org/licenses/LICENSE-2.0
+            #
+            # Unless required by applicable law or agreed to in writing, software
+            # distributed under the License is distributed on an "AS IS" BASIS,
+            # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            # See the License for the specific language governing permissions and
+            # limitations under the License.
+
+            # This script is for master and node instance health monitoring, which is
+            # packed in kube-manifest tarball. It is executed through a systemd service
+            # in cluster/gce/gci/<master/node>.yaml. The env variables come from an env
+            # file provided by the systemd service.
+
+            # This script is a slightly adjusted version of
+            # https://github.com/kubernetes/kubernetes/blob/e1a1aa211224fcd9b213420b80b2ae680669683d/cluster/gce/gci/health-monitor.sh
+            # Adjustments are:
+            # * Kubelet health port is 10248 not 10255
+            # * Removal of all all references to the KUBE_ENV file
+
+            set -o nounset
+            set -o pipefail
+
+            # We simply kill the process when there is a failure. Another systemd service will
+            # automatically restart the process.
+            function container_runtime_monitoring() {
+              local -r max_attempts=5
+              local attempt=1
+              local -r container_runtime_name="${CONTAINER_RUNTIME_NAME:-docker}"
+              # We still need to use 'docker ps' when container runtime is "docker". This is because
+              # dockershim is still part of kubelet today. When kubelet is down, crictl pods
+              # will also fail, and docker will be killed. This is undesirable especially when
+              # docker live restore is disabled.
+              local healthcheck_command="docker ps"
+              if [[ "${CONTAINER_RUNTIME:-docker}" != "docker" ]]; then
+                healthcheck_command="crictl pods"
+              fi
+              # Container runtime startup takes time. Make initial attempts before starting
+              # killing the container runtime.
+              until timeout 60 ${healthcheck_command} > /dev/null; do
+                if ((attempt == max_attempts)); then
+                  echo "Max attempt ${max_attempts} reached! Proceeding to monitor container runtime healthiness."
+                  break
+                fi
+                echo "$attempt initial attempt \"${healthcheck_command}\"! Trying again in $attempt seconds..."
+                sleep "$((2 ** attempt++))"
+              done
+              while true; do
+                if ! timeout 60 ${healthcheck_command} > /dev/null; then
+                  echo "Container runtime ${container_runtime_name} failed!"
+                  if [[ "$container_runtime_name" == "docker" ]]; then
+                    # Dump stack of docker daemon for investigation.
+                    # Log file name looks like goroutine-stacks-TIMESTAMP and will be saved to
+                    # the exec root directory, which is /var/run/docker/ on Ubuntu and COS.
+                    pkill -SIGUSR1 dockerd
+                  fi
+                  systemctl kill --kill-who=main "${container_runtime_name}"
+                  # Wait for a while, as we don't want to kill it again before it is really up.
+                  sleep 120
+                else
+                  sleep "${SLEEP_SECONDS}"
+                fi
+              done
+            }
+
+            function kubelet_monitoring() {
+              echo "Wait for 2 minutes for kubelet to be functional"
+              # TODO(andyzheng0831): replace it with a more reliable method if possible.
+              sleep 120
+              local -r max_seconds=10
+              local output=""
+              while true; do
+                local failed=false
+
+                if journalctl -u kubelet -n 1 | grep -q "use of closed network connection"; then
+                  failed=true
+                  echo "Kubelet stopped posting node status. Restarting"
+                elif ! output=$(curl -m "${max_seconds}" -f -s -S http://127.0.0.1:10248/healthz 2>&1); then
+                  failed=true
+                  # Print the response and/or errors.
+                  echo "$output"
+                fi
+
+                if [[ "$failed" == "true" ]]; then
+                  echo "Kubelet is unhealthy!"
+                  systemctl kill kubelet
+                  # Wait for a while, as we don't want to kill it again before it is really up.
+                  sleep 60
+                else
+                  sleep "${SLEEP_SECONDS}"
+                fi
+              done
+            }
+
+            ############## Main Function ################
+            if [[ "$#" -ne 1 ]]; then
+              echo "Usage: health-monitor.sh <container-runtime/kubelet>"
+              exit 1
+            fi
+
+            SLEEP_SECONDS=10
+            component=$1
+            echo "Start kubernetes health monitoring for ${component}"
+            if [[ "${component}" == "container-runtime" ]]; then
+              container_runtime_monitoring
+            elif [[ "${component}" == "kubelet" ]]; then
+              kubelet_monitoring
+            else
+              echo "Health monitoring for component ${component} is not supported!"
+            fi
+
+    - path: /etc/systemd/system/systemd-networkd.service.d/10-static-network.conf
+      content:
+        inline:
+          data: |
+            {{- if .NetworkConfig }}
+            [Match]
+            # Because of difficulty predicting specific NIC names on different cloud providers,
+            # we only support static addressing on VSphere. There should be a single NIC attached
+            # that we will match by name prefix 'en' which denotes ethernet devices.
+            Name=en*
+
+            [Network]
+            DHCP=no
+            Address={{ .NetworkConfig.CIDR }}
+            Gateway={{ .NetworkConfig.Gateway }}
+            {{ range .NetworkConfig.DNS.Servers }}DNS={{ . }}
+            {{ end }}
+            {{- end }}
+
+    - path: /etc/environment
+      content:
+        inline:
+          data: |
+            {{- if .HTTPProxy }}
+            HTTP_PROXY={{ .HTTPProxy }}
+            http_proxy={{ .HTTPProxy }}
+            HTTPS_PROXY={{ .HTTPProxy }}
+            https_proxy={{ .HTTPProxy }}
+            NO_PROXY={{ .NoProxy }}
+            no_proxy={{ .NoProxy }}
+            {{- end }}
+
+    - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+      content:
+        inline:
+          data: |
+            [Service]
+            Restart=always
+            EnvironmentFile=-/etc/environment
+
+    - path: "/etc/systemd/system/docker.service.d/environment.conf"
+      content:
+        inline:
+          data: |
+            [Service]
+            Restart=always
+            EnvironmentFile=-/etc/environment
+
     - path: /etc/systemd/journald.conf.d/max_disk_use.conf
       content:
         inline:
@@ -349,16 +474,6 @@ spec:
               echo -e "[Service]\nEnvironment=\"KUBELET_NODE_IP=${DEFAULT_IFC_IP}\"\nEnvironment=\"KUBELET_HOSTNAME=${FULL_HOSTNAME}\"" > /etc/systemd/system/kubelet.service.d/nodeip.conf
             fi
 
-    - path: /opt/bin/configure_static_network.sh
-      permissions: 0755
-      content:
-        inline:
-          data: |
-            #!/usr/bin/env bash
-            set -xeuo pipefail
-
-            {{- template "configureStaticNetwork" }}
-
     - path: /opt/bin/download.sh
       permissions: 0755
       content:
@@ -368,6 +483,8 @@ spec:
             set -xeuo pipefail
 
             {{- template "safeDownloadBinariesScript" }}
+
+            {{- template "configureProxyScript" }}
 
             systemctl disable download-script.service
 
@@ -412,7 +529,7 @@ spec:
             systemctl mask locksmithd.service
             {{- end }}
 
-            {{- /* Since both container runtimes are enabled/started by default in flatcar, disable the one that is not required */}}
+            {{- /* Since both container runtimes are enabled/started by default in flatcar, disable the one that is not required */ }}
             {{- if eq .ContainerRuntime "containerd" }}
             systemctl stop docker
             systemctl disable docker
@@ -421,8 +538,6 @@ spec:
             systemctl stop containerd
             systemctl disable containerd
             {{- end }}
-
-            {{- template "configureProxyScript" }}
 
             systemctl enable --now kubelet
             systemctl enable --now --no-block kubelet-healthcheck.service
@@ -467,7 +582,7 @@ spec:
               {{- if .ExternalCloudProvider }}
               --cloud-provider=external \
               {{- else if .InTreeCCMAvailable }}
-              --cloud-provider={{- .CloudProviderName}} \
+              --cloud-provider={{- .CloudProviderName }} \
               --cloud-config=/etc/kubernetes/cloud-config \
               {{- end }}
               {{- if ne .CloudProviderName "aws" }}
@@ -526,7 +641,7 @@ spec:
             - "{{ . }}"
             {{- end }}
             clusterDomain: cluster.local
-            {{- /* containerLogMaxSize and containerLogMaxFiles have no effect for docker  */}}
+            {{- /* containerLogMaxSize and containerLogMaxFiles have no effect for docker  */ }}
             {{- if ne .ContainerRuntime "docker" }}
             {{- if .ContainerLogMaxSize }}
             containerLogMaxSize: {{ .ContainerLogMaxSize }}

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -38,6 +38,14 @@ spec:
               data: |
                 {{ .ContainerRuntimeConfig }}
 
+        - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
         - path: /etc/systemd/system/containerd.service.d/10-custom.conf
           content:
             inline:
@@ -56,6 +64,22 @@ spec:
 
     - name: docker
       files:
+        - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
+        - path: "/etc/systemd/system/docker.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
         - path: /etc/docker/daemon.json
           permissions: 0644
           content:
@@ -367,35 +391,6 @@ spec:
             {{ range .NetworkConfig.DNS.Servers }}DNS={{ . }}
             {{ end }}
             {{- end }}
-
-    - path: /etc/environment
-      content:
-        inline:
-          data: |
-            {{- if .HTTPProxy }}
-            HTTP_PROXY={{ .HTTPProxy }}
-            http_proxy={{ .HTTPProxy }}
-            HTTPS_PROXY={{ .HTTPProxy }}
-            https_proxy={{ .HTTPProxy }}
-            NO_PROXY={{ .NoProxy }}
-            no_proxy={{ .NoProxy }}
-            {{- end }}
-
-    - path: "/etc/systemd/system/containerd.service.d/environment.conf"
-      content:
-        inline:
-          data: |
-            [Service]
-            Restart=always
-            EnvironmentFile=-/etc/environment
-
-    - path: "/etc/systemd/system/docker.service.d/environment.conf"
-      content:
-        inline:
-          data: |
-            [Service]
-            Restart=always
-            EnvironmentFile=-/etc/environment
 
     - path: /etc/systemd/journald.conf.d/max_disk_use.conf
       content:

--- a/deploy/osps/default/osp-rhel.yaml
+++ b/deploy/osps/default/osp-rhel.yaml
@@ -36,6 +36,14 @@ spec:
               data: |
                 runtime-endpoint: unix:///run/containerd/containerd.sock
 
+        - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
         - path: "/etc/containerd/config.toml"
           permissions: 0600
           content:
@@ -61,6 +69,22 @@ spec:
 
     - name: docker
       files:
+        - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
+        - path: "/etc/systemd/system/docker.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
         - path: /etc/docker/daemon.json
           permissions: 0644
           content:
@@ -184,36 +208,19 @@ spec:
           ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
       done
 
+    configureProxyScript: |-
+      {{- if .HTTPProxy }}
+      cat <<EOF | tee -a /etc/environment
+      HTTP_PROXY={{ .HTTPProxy }}
+      http_proxy={{ .HTTPProxy }}
+      HTTPS_PROXY={{ .HTTPProxy }}
+      https_proxy={{ .HTTPProxy }}
+      NO_PROXY={{ .NoProxy }}
+      no_proxy={{ .NoProxy }}
+      EOF
+      {{- end }}
+
   files:
-    - path: /etc/environment
-      content:
-        inline:
-          data: |
-            {{- if .HTTPProxy }}
-            HTTP_PROXY={{ .HTTPProxy }}
-            http_proxy={{ .HTTPProxy }}
-            HTTPS_PROXY={{ .HTTPProxy }}
-            https_proxy={{ .HTTPProxy }}
-            NO_PROXY={{ .NoProxy }}
-            no_proxy={{ .NoProxy }}
-            {{- end }}
-
-    - path: "/etc/systemd/system/containerd.service.d/environment.conf"
-      content:
-        inline:
-          data: |
-            [Service]
-            Restart=always
-            EnvironmentFile=-/etc/environment
-
-    - path: "/etc/systemd/system/docker.service.d/environment.conf"
-      content:
-        inline:
-          data: |
-            [Service]
-            Restart=always
-            EnvironmentFile=-/etc/environment
-
     - path: "/opt/bin/health-monitor.sh"
       permissions: 0755
       content:
@@ -451,6 +458,8 @@ spec:
             {{- template "containerRuntimeInstallation" }}
 
             {{- template "safeDownloadBinariesScript" }}
+
+            {{- template "configureProxyScript" }}
 
             mkdir -p /etc/systemd/system/kubelet.service.d/
             # set kubelet nodeip environment variable

--- a/deploy/osps/default/osp-rhel.yaml
+++ b/deploy/osps/default/osp-rhel.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "rhel"
   osVersion: "8.4"
-  version: "v0.1.1"
+  version: "v0.1.2"
   supportedCloudProviders:
     - name: "aws"
     - name: "azure"
@@ -30,13 +30,19 @@ spec:
   supportedContainerRuntimes:
     - name: containerd
       files:
+        - path: "/etc/crictl.yaml"
+          content:
+            inline:
+              data: |
+                runtime-endpoint: unix:///run/containerd/containerd.sock
+
         - path: "/etc/containerd/config.toml"
-          permissions: 0644
+          permissions: 0600
           content:
             inline:
               encoding: b64
               data: |
-                {{ .ContainerRuntimeConfig}}
+                {{ .ContainerRuntimeConfig }}
       templates:
         containerRuntimeInstallation: |-
           yum install -y yum-utils
@@ -44,19 +50,8 @@ spec:
           {{- /*
               Due to DNF modules we have to do this on docker-ce repo
               More info at: https://bugzilla.redhat.com/show_bug.cgi?id=1756473
-          */}}
+          */ }}
           yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
-
-          cat <<EOF | tee /etc/crictl.yaml
-          runtime-endpoint: unix:///run/containerd/containerd.sock
-          EOF
-
-          mkdir -p /etc/systemd/system/containerd.service.d
-          cat <<EOF | tee /etc/systemd/system/containerd.service.d/environment.conf
-          [Service]
-          Restart=always
-          EnvironmentFile=-/etc/environment
-          EOF
 
           yum install -y containerd.io-1.4* yum-plugin-versionlock
           yum versionlock add containerd.io
@@ -72,20 +67,12 @@ spec:
             inline:
               encoding: b64
               data: |-
-                {{ .ContainerRuntimeConfig}}
+                {{ .ContainerRuntimeConfig }}
       templates:
         containerRuntimeInstallation: |-
           yum install -y yum-utils
           yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
           yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
-
-          mkdir -p /etc/systemd/system/containerd.service.d /etc/systemd/system/docker.service.d
-
-          cat <<EOF | tee /etc/systemd/system/containerd.service.d/environment.conf /etc/systemd/system/docker.service.d/environment.conf
-          [Service]
-          Restart=always
-          EnvironmentFile=-/etc/environment
-          EOF
 
           yum install -y \
               docker-ce-cli-19.03* \
@@ -104,10 +91,10 @@ spec:
       usr_local_bin=/usr/local/bin
       cni_bin_dir=/opt/cni/bin
 
-      {{- /* create all the necessary dirs */}}
+      {{- /* create all the necessary dirs */ }}
       mkdir -p /etc/cni/net.d /etc/kubernetes/dynamic-config-dir /etc/kubernetes/manifests "$opt_bin" "$cni_bin_dir"
 
-      {{- /* HOST_ARCH can be defined outside of machine-controller (in kubeone for example) */}}
+      {{- /* HOST_ARCH can be defined outside of machine-controller (in kubeone for example) */ }}
       arch=${HOST_ARCH-}
       if [ -z "$arch" ]
       then
@@ -125,96 +112,232 @@ spec:
       esac
       fi
 
-      {{- /* # CNI variables */}}
+      {{- /* # CNI variables */ }}
       CNI_VERSION="${CNI_VERSION:-v0.8.7}"
       cni_base_url="https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION"
       cni_filename="cni-plugins-linux-$arch-$CNI_VERSION.tgz"
 
-      {{- /* download CNI */}}
+      {{- /* download CNI */ }}
       curl -Lfo "$cni_bin_dir/$cni_filename" "$cni_base_url/$cni_filename"
 
-      {{- /* download CNI checksum */}}
+      {{- /* download CNI checksum */ }}
       cni_sum=$(curl -Lf "$cni_base_url/$cni_filename.sha256")
       cd "$cni_bin_dir"
 
-      {{- /* verify CNI checksum */}}
+      {{- /* verify CNI checksum */ }}
       sha256sum -c <<<"$cni_sum"
 
-      {{- /* unpack CNI */}}
+      {{- /* unpack CNI */ }}
       tar xvf "$cni_filename"
       rm -f "$cni_filename"
       cd -
 
-      {{- /* # cri-tools variables */}}
+      {{- /* # cri-tools variables */ }}
       CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.22.0}"
       cri_tools_base_url="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}"
       cri_tools_filename="crictl-${CRI_TOOLS_RELEASE}-linux-${arch}.tar.gz"
 
-      {{- /* download cri-tools */}}
+      {{- /* download cri-tools */ }}
       curl -Lfo "$opt_bin/$cri_tools_filename" "$cri_tools_base_url/$cri_tools_filename"
 
-      {{- /* download cri-tools checksum */}}
-      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */}}
+      {{- /* download cri-tools checksum */ }}
+      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */ }}
       cri_tools_sum=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256" | sed 's/\*\///')
       cd "$opt_bin"
 
-      {{- /* verify cri-tools checksum */}}
+      {{- /* verify cri-tools checksum */ }}
       sha256sum -c <<<"$cri_tools_sum"
 
-      {{- /* unpack cri-tools and symlink to path so it's available to all users */}}
+      {{- /* unpack cri-tools and symlink to path so it's available to all users */ }}
       tar xvf "$cri_tools_filename"
       rm -f "$cri_tools_filename"
       ln -sf "$opt_bin/crictl" "$usr_local_bin"/crictl || echo "symbolic link is skipped"
       cd -
 
-      {{- /* kubelet */}}
+      {{- /* kubelet */ }}
       KUBE_VERSION="${KUBE_VERSION:-{{ .KubeVersion }}}"
       kube_dir="$opt_bin/kubernetes-$KUBE_VERSION"
       kube_base_url="https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$arch"
       kube_sum_file="$kube_dir/sha256"
 
-      {{- /* create versioned kube dir */}}
+      {{- /* create versioned kube dir */ }}
       mkdir -p "$kube_dir"
       : >"$kube_sum_file"
 
       for bin in kubelet kubeadm kubectl; do
-          {{- /* download kube binary */}}
+          {{- /* download kube binary */ }}
           curl -Lfo "$kube_dir/$bin" "$kube_base_url/$bin"
           chmod +x "$kube_dir/$bin"
 
-          {{- /* download kube binary checksum */}}
+          {{- /* download kube binary checksum */ }}
           sum=$(curl -Lf "$kube_base_url/$bin.sha256")
 
-          {{- /* save kube binary checksum */}}
+          {{- /* save kube binary checksum */ }}
           echo "$sum  $kube_dir/$bin" >>"$kube_sum_file"
       done
 
-      {{- /* check kube binaries checksum */}}
+      {{- /* check kube binaries checksum */ }}
       sha256sum -c "$kube_sum_file"
 
       for bin in kubelet kubeadm kubectl; do
-          {{- /* link kube binaries from verioned dir to $opt_bin */}}
+          {{- /* link kube binaries from verioned dir to $opt_bin */ }}
           ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
       done
 
-      if [[ ! -x /opt/bin/health-monitor.sh ]]; then
-          curl -Lfo /opt/bin/health-monitor.sh https://raw.githubusercontent.com/kubermatic/machine-controller/7967a0af2b75f29ad2ab227eeaa26ea7b0f2fbde/pkg/userdata/scripts/health-monitor.sh
-          chmod +x /opt/bin/health-monitor.sh
-      fi
-
-    configureProxyScript: |-
-      {{- if .HTTPProxy }}
-      cat <<EOF | tee -a /etc/environment
-      HTTP_PROXY={{ .HTTPProxy }}
-      http_proxy={{ .HTTPProxy }}
-      HTTPS_PROXY={{ .HTTPProxy }}
-      https_proxy={{ .HTTPProxy }}
-      NO_PROXY={{ .NoProxy }}
-      no_proxy={{ .NoProxy }}
-      EOF
-      {{- end }}
-
   files:
+    - path: /etc/environment
+      content:
+        inline:
+          data: |
+            {{- if .HTTPProxy }}
+            HTTP_PROXY={{ .HTTPProxy }}
+            http_proxy={{ .HTTPProxy }}
+            HTTPS_PROXY={{ .HTTPProxy }}
+            https_proxy={{ .HTTPProxy }}
+            NO_PROXY={{ .NoProxy }}
+            no_proxy={{ .NoProxy }}
+            {{- end }}
+
+    - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+      content:
+        inline:
+          data: |
+            [Service]
+            Restart=always
+            EnvironmentFile=-/etc/environment
+
+    - path: "/etc/systemd/system/docker.service.d/environment.conf"
+      content:
+        inline:
+          data: |
+            [Service]
+            Restart=always
+            EnvironmentFile=-/etc/environment
+
+    - path: "/opt/bin/health-monitor.sh"
+      permissions: 0755
+      content:
+        inline:
+          encoding: b64
+          data: |
+            #!/usr/bin/env bash
+
+            # Copyright 2016 The Kubernetes Authors.
+            #
+            # Licensed under the Apache License, Version 2.0 (the "License");
+            # you may not use this file except in compliance with the License.
+            # You may obtain a copy of the License at
+            #
+            #     http://www.apache.org/licenses/LICENSE-2.0
+            #
+            # Unless required by applicable law or agreed to in writing, software
+            # distributed under the License is distributed on an "AS IS" BASIS,
+            # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            # See the License for the specific language governing permissions and
+            # limitations under the License.
+
+            # This script is for master and node instance health monitoring, which is
+            # packed in kube-manifest tarball. It is executed through a systemd service
+            # in cluster/gce/gci/<master/node>.yaml. The env variables come from an env
+            # file provided by the systemd service.
+
+            # This script is a slightly adjusted version of
+            # https://github.com/kubernetes/kubernetes/blob/e1a1aa211224fcd9b213420b80b2ae680669683d/cluster/gce/gci/health-monitor.sh
+            # Adjustments are:
+            # * Kubelet health port is 10248 not 10255
+            # * Removal of all all references to the KUBE_ENV file
+
+            set -o nounset
+            set -o pipefail
+
+            # We simply kill the process when there is a failure. Another systemd service will
+            # automatically restart the process.
+            function container_runtime_monitoring() {
+              local -r max_attempts=5
+              local attempt=1
+              local -r container_runtime_name="${CONTAINER_RUNTIME_NAME:-docker}"
+              # We still need to use 'docker ps' when container runtime is "docker". This is because
+              # dockershim is still part of kubelet today. When kubelet is down, crictl pods
+              # will also fail, and docker will be killed. This is undesirable especially when
+              # docker live restore is disabled.
+              local healthcheck_command="docker ps"
+              if [[ "${CONTAINER_RUNTIME:-docker}" != "docker" ]]; then
+                healthcheck_command="crictl pods"
+              fi
+              # Container runtime startup takes time. Make initial attempts before starting
+              # killing the container runtime.
+              until timeout 60 ${healthcheck_command} > /dev/null; do
+                if ((attempt == max_attempts)); then
+                  echo "Max attempt ${max_attempts} reached! Proceeding to monitor container runtime healthiness."
+                  break
+                fi
+                echo "$attempt initial attempt \"${healthcheck_command}\"! Trying again in $attempt seconds..."
+                sleep "$((2 ** attempt++))"
+              done
+              while true; do
+                if ! timeout 60 ${healthcheck_command} > /dev/null; then
+                  echo "Container runtime ${container_runtime_name} failed!"
+                  if [[ "$container_runtime_name" == "docker" ]]; then
+                    # Dump stack of docker daemon for investigation.
+                    # Log file name looks like goroutine-stacks-TIMESTAMP and will be saved to
+                    # the exec root directory, which is /var/run/docker/ on Ubuntu and COS.
+                    pkill -SIGUSR1 dockerd
+                  fi
+                  systemctl kill --kill-who=main "${container_runtime_name}"
+                  # Wait for a while, as we don't want to kill it again before it is really up.
+                  sleep 120
+                else
+                  sleep "${SLEEP_SECONDS}"
+                fi
+              done
+            }
+
+            function kubelet_monitoring() {
+              echo "Wait for 2 minutes for kubelet to be functional"
+              # TODO(andyzheng0831): replace it with a more reliable method if possible.
+              sleep 120
+              local -r max_seconds=10
+              local output=""
+              while true; do
+                local failed=false
+
+                if journalctl -u kubelet -n 1 | grep -q "use of closed network connection"; then
+                  failed=true
+                  echo "Kubelet stopped posting node status. Restarting"
+                elif ! output=$(curl -m "${max_seconds}" -f -s -S http://127.0.0.1:10248/healthz 2>&1); then
+                  failed=true
+                  # Print the response and/or errors.
+                  echo "$output"
+                fi
+
+                if [[ "$failed" == "true" ]]; then
+                  echo "Kubelet is unhealthy!"
+                  systemctl kill kubelet
+                  # Wait for a while, as we don't want to kill it again before it is really up.
+                  sleep 60
+                else
+                  sleep "${SLEEP_SECONDS}"
+                fi
+              done
+            }
+
+            ############## Main Function ################
+            if [[ "$#" -ne 1 ]]; then
+              echo "Usage: health-monitor.sh <container-runtime/kubelet>"
+              exit 1
+            fi
+
+            SLEEP_SECONDS=10
+            component=$1
+            echo "Start kubernetes health monitoring for ${component}"
+            if [[ "${component}" == "container-runtime" ]]; then
+              container_runtime_monitoring
+            elif [[ "${component}" == "kubelet" ]]; then
+              kubelet_monitoring
+            else
+              echo "Health monitoring for component ${component} is not supported!"
+            fi
+
     - path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
       content:
         inline:
@@ -284,11 +407,11 @@ spec:
 
             setenforce 0 || true
 
-            {{- /* As we added some modules and don't want to reboot, restart the service */}}
+            {{- /* As we added some modules and don't want to reboot, restart the service */ }}
             systemctl restart systemd-modules-load.service
             sysctl --system
 
-            {{- /* Make sure we always disable swap - Otherwise the kubelet won't start'. */}}
+            {{- /* Make sure we always disable swap - Otherwise the kubelet won't start'. */ }}
             sed -i.orig '/.*swap.*/d' /etc/fstab
             swapoff -a
 
@@ -320,7 +443,7 @@ spec:
               {{- end }}
               ipvsadm
 
-            {{- /* iscsid service is required on Nutanix machines for CSI driver to attach volumes. */}}
+            {{- /* iscsid service is required on Nutanix machines for CSI driver to attach volumes. */ }}
             {{- if eq .CloudProviderName "nutanix" }}
             systemctl enable --now iscsid
             {{ end }}
@@ -384,7 +507,7 @@ spec:
               {{- if .ExternalCloudProvider }}
               --cloud-provider=external \
               {{- else if .InTreeCCMAvailable }}
-              --cloud-provider={{- .CloudProviderName}} \
+              --cloud-provider={{- .CloudProviderName }} \
               --cloud-config=/etc/kubernetes/cloud-config \
               {{- end }}
               {{- if ne .CloudProviderName "aws" }}
@@ -515,7 +638,7 @@ spec:
             - "{{ . }}"
             {{- end }}
             clusterDomain: cluster.local
-            {{- /* containerLogMaxSize and containerLogMaxFiles have no effect for docker  */}}
+            {{- /* containerLogMaxSize and containerLogMaxFiles have no effect for docker  */ }}
             {{- if ne .ContainerRuntime "docker" }}
             {{- if .ContainerLogMaxSize }}
             containerLogMaxSize: {{ .ContainerLogMaxSize }}

--- a/deploy/osps/default/osp-sles.yaml
+++ b/deploy/osps/default/osp-sles.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: sles
   osVersion: "15-SP-1"
-  version: "v0.1.1"
+  version: "v0.1.2"
   supportedCloudProviders:
     - name: aws
   supportedContainerRuntimes:
@@ -32,14 +32,7 @@ spec:
             inline:
               encoding: b64
               data: |-
-                {{ .ContainerRuntimeConfig}}
-        - path: /etc/systemd/system/docker.service.d/10-custom.conf
-          permissions: 0644
-          content:
-            inline:
-              data: |-
-                [Service]
-                EnvironmentFile=-/etc/environment
+                {{ .ContainerRuntimeConfig }}
 
   templates:
     safeDownloadBinariesScript: |-
@@ -47,10 +40,10 @@ spec:
       usr_local_bin=/usr/local/bin
       cni_bin_dir=/opt/cni/bin
 
-      {{- /* create all the necessary dirs */}}
+      {{- /* create all the necessary dirs */ }}
       mkdir -p /etc/cni/net.d /etc/kubernetes/dynamic-config-dir /etc/kubernetes/manifests "$opt_bin" "$cni_bin_dir"
 
-      {{- /* HOST_ARCH can be defined outside of machine-controller (in kubeone for example) */}}
+      {{- /* HOST_ARCH can be defined outside of machine-controller (in kubeone for example) */ }}
       arch=${HOST_ARCH-}
       if [ -z "$arch" ]
       then
@@ -68,82 +61,77 @@ spec:
       esac
       fi
 
-      {{- /* # CNI variables */}}
+      {{- /* # CNI variables */ }}
       CNI_VERSION="${CNI_VERSION:-v0.8.7}"
       cni_base_url="https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION"
       cni_filename="cni-plugins-linux-$arch-$CNI_VERSION.tgz"
 
-      {{- /* download CNI */}}
+      {{- /* download CNI */ }}
       curl -Lfo "$cni_bin_dir/$cni_filename" "$cni_base_url/$cni_filename"
 
-      {{- /* download CNI checksum */}}
+      {{- /* download CNI checksum */ }}
       cni_sum=$(curl -Lf "$cni_base_url/$cni_filename.sha256")
       cd "$cni_bin_dir"
 
-      {{- /* verify CNI checksum */}}
+      {{- /* verify CNI checksum */ }}
       sha256sum -c <<<"$cni_sum"
 
-      {{- /* unpack CNI */}}
+      {{- /* unpack CNI */ }}
       tar xvf "$cni_filename"
       rm -f "$cni_filename"
       cd -
 
-      {{- /* # cri-tools variables */}}
+      {{- /* # cri-tools variables */ }}
       CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.22.0}"
       cri_tools_base_url="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}"
       cri_tools_filename="crictl-${CRI_TOOLS_RELEASE}-linux-${arch}.tar.gz"
 
-      {{- /* download cri-tools */}}
+      {{- /* download cri-tools */ }}
       curl -Lfo "$opt_bin/$cri_tools_filename" "$cri_tools_base_url/$cri_tools_filename"
 
-      {{- /* download cri-tools checksum */}}
-      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */}}
+      {{- /* download cri-tools checksum */ }}
+      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */ }}
       cri_tools_sum=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256" | sed 's/\*\///')
       cd "$opt_bin"
 
-      {{- /* verify cri-tools checksum */}}
+      {{- /* verify cri-tools checksum */ }}
       sha256sum -c <<<"$cri_tools_sum"
 
-      {{- /* unpack cri-tools and symlink to path so it's available to all users */}}
+      {{- /* unpack cri-tools and symlink to path so it's available to all users */ }}
       tar xvf "$cri_tools_filename"
       rm -f "$cri_tools_filename"
       ln -sf "$opt_bin/crictl" "$usr_local_bin"/crictl || echo "symbolic link is skipped"
       cd -
 
-      {{- /* kubelet */}}
+      {{- /* kubelet */ }}
       KUBE_VERSION="${KUBE_VERSION:-{{ .KubeVersion }}}"
       kube_dir="$opt_bin/kubernetes-$KUBE_VERSION"
       kube_base_url="https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$arch"
       kube_sum_file="$kube_dir/sha256"
 
-      {{- /* create versioned kube dir */}}
+      {{- /* create versioned kube dir */ }}
       mkdir -p "$kube_dir"
       : >"$kube_sum_file"
 
       for bin in kubelet kubeadm kubectl; do
-          {{- /* download kube binary */}}
+          {{- /* download kube binary */ }}
           curl -Lfo "$kube_dir/$bin" "$kube_base_url/$bin"
           chmod +x "$kube_dir/$bin"
 
-          {{- /* download kube binary checksum */}}
+          {{- /* download kube binary checksum */ }}
           sum=$(curl -Lf "$kube_base_url/$bin.sha256")
 
-          {{- /* save kube binary checksum */}}
+          {{- /* save kube binary checksum */ }}
           echo "$sum  $kube_dir/$bin" >>"$kube_sum_file"
       done
 
-      {{- /* check kube binaries checksum */}}
+      {{- /* check kube binaries checksum */ }}
       sha256sum -c "$kube_sum_file"
 
       for bin in kubelet kubeadm kubectl; do
-          {{- /* link kube binaries from verioned dir to $opt_bin */}}
+          {{- /* link kube binaries from verioned dir to $opt_bin */ }}
           ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
       done
-
-      if [[ ! -x /opt/bin/health-monitor.sh ]]; then
-          curl -Lfo /opt/bin/health-monitor.sh https://raw.githubusercontent.com/kubermatic/machine-controller/7967a0af2b75f29ad2ab227eeaa26ea7b0f2fbde/pkg/userdata/scripts/health-monitor.sh
-          chmod +x /opt/bin/health-monitor.sh
-      fi
 
     configureProxyScript: |-
       {{- if .HTTPProxy }}
@@ -158,6 +146,159 @@ spec:
       {{- end }}
 
   files:
+    - path: /etc/environment
+      content:
+        inline:
+          data: |
+            {{- if .HTTPProxy }}
+            HTTP_PROXY={{ .HTTPProxy }}
+            http_proxy={{ .HTTPProxy }}
+            HTTPS_PROXY={{ .HTTPProxy }}
+            https_proxy={{ .HTTPProxy }}
+            NO_PROXY={{ .NoProxy }}
+            no_proxy={{ .NoProxy }}
+            {{- end }}
+
+    - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+      content:
+        inline:
+          data: |
+            [Service]
+            Restart=always
+            EnvironmentFile=-/etc/environment
+
+    - path: "/etc/systemd/system/docker.service.d/environment.conf"
+      content:
+        inline:
+          data: |
+            [Service]
+            Restart=always
+            EnvironmentFile=-/etc/environment
+
+    - path: "/opt/bin/health-monitor.sh"
+      permissions: 0755
+      content:
+        inline:
+          encoding: b64
+          data: |
+            #!/usr/bin/env bash
+
+            # Copyright 2016 The Kubernetes Authors.
+            #
+            # Licensed under the Apache License, Version 2.0 (the "License");
+            # you may not use this file except in compliance with the License.
+            # You may obtain a copy of the License at
+            #
+            #     http://www.apache.org/licenses/LICENSE-2.0
+            #
+            # Unless required by applicable law or agreed to in writing, software
+            # distributed under the License is distributed on an "AS IS" BASIS,
+            # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            # See the License for the specific language governing permissions and
+            # limitations under the License.
+
+            # This script is for master and node instance health monitoring, which is
+            # packed in kube-manifest tarball. It is executed through a systemd service
+            # in cluster/gce/gci/<master/node>.yaml. The env variables come from an env
+            # file provided by the systemd service.
+
+            # This script is a slightly adjusted version of
+            # https://github.com/kubernetes/kubernetes/blob/e1a1aa211224fcd9b213420b80b2ae680669683d/cluster/gce/gci/health-monitor.sh
+            # Adjustments are:
+            # * Kubelet health port is 10248 not 10255
+            # * Removal of all all references to the KUBE_ENV file
+
+            set -o nounset
+            set -o pipefail
+
+            # We simply kill the process when there is a failure. Another systemd service will
+            # automatically restart the process.
+            function container_runtime_monitoring() {
+              local -r max_attempts=5
+              local attempt=1
+              local -r container_runtime_name="${CONTAINER_RUNTIME_NAME:-docker}"
+              # We still need to use 'docker ps' when container runtime is "docker". This is because
+              # dockershim is still part of kubelet today. When kubelet is down, crictl pods
+              # will also fail, and docker will be killed. This is undesirable especially when
+              # docker live restore is disabled.
+              local healthcheck_command="docker ps"
+              if [[ "${CONTAINER_RUNTIME:-docker}" != "docker" ]]; then
+                healthcheck_command="crictl pods"
+              fi
+              # Container runtime startup takes time. Make initial attempts before starting
+              # killing the container runtime.
+              until timeout 60 ${healthcheck_command} > /dev/null; do
+                if ((attempt == max_attempts)); then
+                  echo "Max attempt ${max_attempts} reached! Proceeding to monitor container runtime healthiness."
+                  break
+                fi
+                echo "$attempt initial attempt \"${healthcheck_command}\"! Trying again in $attempt seconds..."
+                sleep "$((2 ** attempt++))"
+              done
+              while true; do
+                if ! timeout 60 ${healthcheck_command} > /dev/null; then
+                  echo "Container runtime ${container_runtime_name} failed!"
+                  if [[ "$container_runtime_name" == "docker" ]]; then
+                    # Dump stack of docker daemon for investigation.
+                    # Log file name looks like goroutine-stacks-TIMESTAMP and will be saved to
+                    # the exec root directory, which is /var/run/docker/ on Ubuntu and COS.
+                    pkill -SIGUSR1 dockerd
+                  fi
+                  systemctl kill --kill-who=main "${container_runtime_name}"
+                  # Wait for a while, as we don't want to kill it again before it is really up.
+                  sleep 120
+                else
+                  sleep "${SLEEP_SECONDS}"
+                fi
+              done
+            }
+
+            function kubelet_monitoring() {
+              echo "Wait for 2 minutes for kubelet to be functional"
+              # TODO(andyzheng0831): replace it with a more reliable method if possible.
+              sleep 120
+              local -r max_seconds=10
+              local output=""
+              while true; do
+                local failed=false
+
+                if journalctl -u kubelet -n 1 | grep -q "use of closed network connection"; then
+                  failed=true
+                  echo "Kubelet stopped posting node status. Restarting"
+                elif ! output=$(curl -m "${max_seconds}" -f -s -S http://127.0.0.1:10248/healthz 2>&1); then
+                  failed=true
+                  # Print the response and/or errors.
+                  echo "$output"
+                fi
+
+                if [[ "$failed" == "true" ]]; then
+                  echo "Kubelet is unhealthy!"
+                  systemctl kill kubelet
+                  # Wait for a while, as we don't want to kill it again before it is really up.
+                  sleep 60
+                else
+                  sleep "${SLEEP_SECONDS}"
+                fi
+              done
+            }
+
+            ############## Main Function ################
+            if [[ "$#" -ne 1 ]]; then
+              echo "Usage: health-monitor.sh <container-runtime/kubelet>"
+              exit 1
+            fi
+
+            SLEEP_SECONDS=10
+            component=$1
+            echo "Start kubernetes health monitoring for ${component}"
+            if [[ "${component}" == "container-runtime" ]]; then
+              container_runtime_monitoring
+            elif [[ "${component}" == "kubelet" ]]; then
+              kubelet_monitoring
+            else
+              echo "Health monitoring for component ${component} is not supported!"
+            fi
+
     - path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
       content:
         inline:
@@ -208,11 +349,11 @@ spec:
             #!/bin/bash
             set -xeuo pipefail
 
-            {{- /* As we added some modules and don't want to reboot, restart the service */}}
+            {{- /* As we added some modules and don't want to reboot, restart the service */ }}
             systemctl restart systemd-modules-load.service
             sysctl --system
 
-            {{- /* Make sure we always disable swap - Otherwise the kubelet won't start'. */}}
+            {{- /* Make sure we always disable swap - Otherwise the kubelet won't start'. */ }}
             cp /etc/fstab /etc/fstab.orig
             cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
             mv /etc/fstab.noswap /etc/fstab
@@ -229,9 +370,9 @@ spec:
               {{- end }}
               ipvsadm
 
-            {{- template "configureProxyScript" }}
-
             {{- template "safeDownloadBinariesScript" }}
+
+            {{- template "configureProxyScript" }}
 
             # set kubelet nodeip environment variable
             /opt/bin/setup_net_env.sh
@@ -285,7 +426,7 @@ spec:
               {{- if .ExternalCloudProvider }}
               --cloud-provider=external \
               {{- else if .InTreeCCMAvailable }}
-              --cloud-provider={{- .CloudProviderName}} \
+              --cloud-provider={{- .CloudProviderName }} \
               --cloud-config=/etc/kubernetes/cloud-config \
               {{- end }}
               {{- if ne .CloudProviderName "aws" }}
@@ -436,7 +577,7 @@ spec:
             - "{{ . }}"
             {{- end }}
             clusterDomain: cluster.local
-            {{- /* containerLogMaxSize and containerLogMaxFiles have no effect for docker  */}}
+            {{- /* containerLogMaxSize and containerLogMaxFiles have no effect for docker  */ }}
             {{- if ne .ContainerRuntime "docker" }}
             {{- if .ContainerLogMaxSize }}
             containerLogMaxSize: {{ .ContainerLogMaxSize }}

--- a/deploy/osps/default/osp-sles.yaml
+++ b/deploy/osps/default/osp-sles.yaml
@@ -26,6 +26,22 @@ spec:
   supportedContainerRuntimes:
     - name: docker
       files:
+        - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
+        - path: "/etc/systemd/system/docker.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
         - path: /etc/docker/daemon.json
           permissions: 0644
           content:
@@ -146,35 +162,6 @@ spec:
       {{- end }}
 
   files:
-    - path: /etc/environment
-      content:
-        inline:
-          data: |
-            {{- if .HTTPProxy }}
-            HTTP_PROXY={{ .HTTPProxy }}
-            http_proxy={{ .HTTPProxy }}
-            HTTPS_PROXY={{ .HTTPProxy }}
-            https_proxy={{ .HTTPProxy }}
-            NO_PROXY={{ .NoProxy }}
-            no_proxy={{ .NoProxy }}
-            {{- end }}
-
-    - path: "/etc/systemd/system/containerd.service.d/environment.conf"
-      content:
-        inline:
-          data: |
-            [Service]
-            Restart=always
-            EnvironmentFile=-/etc/environment
-
-    - path: "/etc/systemd/system/docker.service.d/environment.conf"
-      content:
-        inline:
-          data: |
-            [Service]
-            Restart=always
-            EnvironmentFile=-/etc/environment
-
     - path: "/opt/bin/health-monitor.sh"
       permissions: 0755
       content:

--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "ubuntu"
   osVersion: "20.04"
-  version: "v0.1.1"
+  version: "v0.1.2"
   supportedCloudProviders:
     - name: "aws"
     - name: "azure"
@@ -34,30 +34,25 @@ spec:
   supportedContainerRuntimes:
     - name: containerd
       files:
+        - path: "/etc/crictl.yaml"
+          content:
+            inline:
+              data: |
+                runtime-endpoint: unix:///run/containerd/containerd.sock
+
         - path: "/etc/containerd/config.toml"
-          permissions: 0644
+          permissions: 0600
           content:
             inline:
               encoding: b64
               data: |
-                {{ .ContainerRuntimeConfig}}
+                {{ .ContainerRuntimeConfig }}
       templates:
         containerRuntimeInstallation: |-
           apt-get update
           apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
           add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-
-          cat <<EOF | tee /etc/crictl.yaml
-          runtime-endpoint: unix:///run/containerd/containerd.sock
-          EOF
-
-          mkdir -p /etc/systemd/system/containerd.service.d
-          cat <<EOF | tee /etc/systemd/system/containerd.service.d/environment.conf
-          [Service]
-          Restart=always
-          EnvironmentFile=-/etc/environment
-          EOF
 
           apt-get install -y --allow-downgrades containerd.io=1.4*
           apt-mark hold containerd.io
@@ -73,21 +68,14 @@ spec:
             inline:
               encoding: b64
               data: |-
-                {{ .ContainerRuntimeConfig}}
+                {{ .ContainerRuntimeConfig }}
+
       templates:
         containerRuntimeInstallation: |-
           apt-get update
           apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
           add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-
-          mkdir -p /etc/systemd/system/containerd.service.d /etc/systemd/system/docker.service.d
-
-          cat <<EOF | tee /etc/systemd/system/containerd.service.d/environment.conf /etc/systemd/system/docker.service.d/environment.conf
-          [Service]
-          Restart=always
-          EnvironmentFile=-/etc/environment
-          EOF
 
           apt-get install --allow-downgrades -y \
               containerd.io=1.4* \
@@ -105,10 +93,10 @@ spec:
       usr_local_bin=/usr/local/bin
       cni_bin_dir=/opt/cni/bin
 
-      {{- /* create all the necessary dirs */}}
+      {{- /* create all the necessary dirs */ }}
       mkdir -p /etc/cni/net.d /etc/kubernetes/dynamic-config-dir /etc/kubernetes/manifests "$opt_bin" "$cni_bin_dir"
 
-      {{- /* HOST_ARCH can be defined outside of machine-controller (in kubeone for example) */}}
+      {{- /* HOST_ARCH can be defined outside of machine-controller (in kubeone for example) */ }}
       arch=${HOST_ARCH-}
       if [ -z "$arch" ]
       then
@@ -126,82 +114,77 @@ spec:
       esac
       fi
 
-      {{- /* # CNI variables */}}
+      {{- /* # CNI variables */ }}
       CNI_VERSION="${CNI_VERSION:-v0.8.7}"
       cni_base_url="https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION"
       cni_filename="cni-plugins-linux-$arch-$CNI_VERSION.tgz"
 
-      {{- /* download CNI */}}
+      {{- /* download CNI */ }}
       curl -Lfo "$cni_bin_dir/$cni_filename" "$cni_base_url/$cni_filename"
 
-      {{- /* download CNI checksum */}}
+      {{- /* download CNI checksum */ }}
       cni_sum=$(curl -Lf "$cni_base_url/$cni_filename.sha256")
       cd "$cni_bin_dir"
 
-      {{- /* verify CNI checksum */}}
+      {{- /* verify CNI checksum */ }}
       sha256sum -c <<<"$cni_sum"
 
-      {{- /* unpack CNI */}}
+      {{- /* unpack CNI */ }}
       tar xvf "$cni_filename"
       rm -f "$cni_filename"
       cd -
 
-      {{- /* # cri-tools variables */}}
+      {{- /* # cri-tools variables */ }}
       CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.22.0}"
       cri_tools_base_url="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}"
       cri_tools_filename="crictl-${CRI_TOOLS_RELEASE}-linux-${arch}.tar.gz"
 
-      {{- /* download cri-tools */}}
+      {{- /* download cri-tools */ }}
       curl -Lfo "$opt_bin/$cri_tools_filename" "$cri_tools_base_url/$cri_tools_filename"
 
-      {{- /* download cri-tools checksum */}}
-      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */}}
+      {{- /* download cri-tools checksum */ }}
+      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */ }}
       cri_tools_sum=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256" | sed 's/\*\///')
       cd "$opt_bin"
 
-      {{- /* verify cri-tools checksum */}}
+      {{- /* verify cri-tools checksum */ }}
       sha256sum -c <<<"$cri_tools_sum"
 
-      {{- /* unpack cri-tools and symlink to path so it's available to all users */}}
+      {{- /* unpack cri-tools and symlink to path so it's available to all users */ }}
       tar xvf "$cri_tools_filename"
       rm -f "$cri_tools_filename"
       ln -sf "$opt_bin/crictl" "$usr_local_bin"/crictl || echo "symbolic link is skipped"
       cd -
 
-      {{- /* kubelet */}}
+      {{- /* kubelet */ }}
       KUBE_VERSION="${KUBE_VERSION:-{{ .KubeVersion }}}"
       kube_dir="$opt_bin/kubernetes-$KUBE_VERSION"
       kube_base_url="https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$arch"
       kube_sum_file="$kube_dir/sha256"
 
-      {{- /* create versioned kube dir */}}
+      {{- /* create versioned kube dir */ }}
       mkdir -p "$kube_dir"
       : >"$kube_sum_file"
 
       for bin in kubelet kubeadm kubectl; do
-          {{- /* download kube binary */}}
+          {{- /* download kube binary */ }}
           curl -Lfo "$kube_dir/$bin" "$kube_base_url/$bin"
           chmod +x "$kube_dir/$bin"
 
-          {{- /* download kube binary checksum */}}
+          {{- /* download kube binary checksum */ }}
           sum=$(curl -Lf "$kube_base_url/$bin.sha256")
 
-          {{- /* save kube binary checksum */}}
+          {{- /* save kube binary checksum */ }}
           echo "$sum  $kube_dir/$bin" >>"$kube_sum_file"
       done
 
-      {{- /* check kube binaries checksum */}}
+      {{- /* check kube binaries checksum */ }}
       sha256sum -c "$kube_sum_file"
 
       for bin in kubelet kubeadm kubectl; do
-          {{- /* link kube binaries from verioned dir to $opt_bin */}}
+          {{- /* link kube binaries from verioned dir to $opt_bin */ }}
           ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
       done
-
-      if [[ ! -x /opt/bin/health-monitor.sh ]]; then
-          curl -Lfo /opt/bin/health-monitor.sh https://raw.githubusercontent.com/kubermatic/machine-controller/7967a0af2b75f29ad2ab227eeaa26ea7b0f2fbde/pkg/userdata/scripts/health-monitor.sh
-          chmod +x /opt/bin/health-monitor.sh
-      fi
 
     configureProxyScript: |-
       {{- if .HTTPProxy }}
@@ -216,6 +199,159 @@ spec:
       {{- end }}
 
   files:
+    - path: /etc/environment
+      content:
+        inline:
+          data: |
+            {{- if .HTTPProxy }}
+            HTTP_PROXY={{ .HTTPProxy }}
+            http_proxy={{ .HTTPProxy }}
+            HTTPS_PROXY={{ .HTTPProxy }}
+            https_proxy={{ .HTTPProxy }}
+            NO_PROXY={{ .NoProxy }}
+            no_proxy={{ .NoProxy }}
+            {{- end }}
+
+    - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+      content:
+        inline:
+          data: |
+            [Service]
+            Restart=always
+            EnvironmentFile=-/etc/environment
+
+    - path: "/etc/systemd/system/docker.service.d/environment.conf"
+      content:
+        inline:
+          data: |
+            [Service]
+            Restart=always
+            EnvironmentFile=-/etc/environment
+
+    - path: "/opt/bin/health-monitor.sh"
+      permissions: 0755
+      content:
+        inline:
+          encoding: b64
+          data: |
+            #!/usr/bin/env bash
+
+            # Copyright 2016 The Kubernetes Authors.
+            #
+            # Licensed under the Apache License, Version 2.0 (the "License");
+            # you may not use this file except in compliance with the License.
+            # You may obtain a copy of the License at
+            #
+            #     http://www.apache.org/licenses/LICENSE-2.0
+            #
+            # Unless required by applicable law or agreed to in writing, software
+            # distributed under the License is distributed on an "AS IS" BASIS,
+            # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            # See the License for the specific language governing permissions and
+            # limitations under the License.
+
+            # This script is for master and node instance health monitoring, which is
+            # packed in kube-manifest tarball. It is executed through a systemd service
+            # in cluster/gce/gci/<master/node>.yaml. The env variables come from an env
+            # file provided by the systemd service.
+
+            # This script is a slightly adjusted version of
+            # https://github.com/kubernetes/kubernetes/blob/e1a1aa211224fcd9b213420b80b2ae680669683d/cluster/gce/gci/health-monitor.sh
+            # Adjustments are:
+            # * Kubelet health port is 10248 not 10255
+            # * Removal of all all references to the KUBE_ENV file
+
+            set -o nounset
+            set -o pipefail
+
+            # We simply kill the process when there is a failure. Another systemd service will
+            # automatically restart the process.
+            function container_runtime_monitoring() {
+              local -r max_attempts=5
+              local attempt=1
+              local -r container_runtime_name="${CONTAINER_RUNTIME_NAME:-docker}"
+              # We still need to use 'docker ps' when container runtime is "docker". This is because
+              # dockershim is still part of kubelet today. When kubelet is down, crictl pods
+              # will also fail, and docker will be killed. This is undesirable especially when
+              # docker live restore is disabled.
+              local healthcheck_command="docker ps"
+              if [[ "${CONTAINER_RUNTIME:-docker}" != "docker" ]]; then
+                healthcheck_command="crictl pods"
+              fi
+              # Container runtime startup takes time. Make initial attempts before starting
+              # killing the container runtime.
+              until timeout 60 ${healthcheck_command} > /dev/null; do
+                if ((attempt == max_attempts)); then
+                  echo "Max attempt ${max_attempts} reached! Proceeding to monitor container runtime healthiness."
+                  break
+                fi
+                echo "$attempt initial attempt \"${healthcheck_command}\"! Trying again in $attempt seconds..."
+                sleep "$((2 ** attempt++))"
+              done
+              while true; do
+                if ! timeout 60 ${healthcheck_command} > /dev/null; then
+                  echo "Container runtime ${container_runtime_name} failed!"
+                  if [[ "$container_runtime_name" == "docker" ]]; then
+                    # Dump stack of docker daemon for investigation.
+                    # Log file name looks like goroutine-stacks-TIMESTAMP and will be saved to
+                    # the exec root directory, which is /var/run/docker/ on Ubuntu and COS.
+                    pkill -SIGUSR1 dockerd
+                  fi
+                  systemctl kill --kill-who=main "${container_runtime_name}"
+                  # Wait for a while, as we don't want to kill it again before it is really up.
+                  sleep 120
+                else
+                  sleep "${SLEEP_SECONDS}"
+                fi
+              done
+            }
+
+            function kubelet_monitoring() {
+              echo "Wait for 2 minutes for kubelet to be functional"
+              # TODO(andyzheng0831): replace it with a more reliable method if possible.
+              sleep 120
+              local -r max_seconds=10
+              local output=""
+              while true; do
+                local failed=false
+
+                if journalctl -u kubelet -n 1 | grep -q "use of closed network connection"; then
+                  failed=true
+                  echo "Kubelet stopped posting node status. Restarting"
+                elif ! output=$(curl -m "${max_seconds}" -f -s -S http://127.0.0.1:10248/healthz 2>&1); then
+                  failed=true
+                  # Print the response and/or errors.
+                  echo "$output"
+                fi
+
+                if [[ "$failed" == "true" ]]; then
+                  echo "Kubelet is unhealthy!"
+                  systemctl kill kubelet
+                  # Wait for a while, as we don't want to kill it again before it is really up.
+                  sleep 60
+                else
+                  sleep "${SLEEP_SECONDS}"
+                fi
+              done
+            }
+
+            ############## Main Function ################
+            if [[ "$#" -ne 1 ]]; then
+              echo "Usage: health-monitor.sh <container-runtime/kubelet>"
+              exit 1
+            fi
+
+            SLEEP_SECONDS=10
+            component=$1
+            echo "Start kubernetes health monitoring for ${component}"
+            if [[ "${component}" == "container-runtime" ]]; then
+              container_runtime_monitoring
+            elif [[ "${component}" == "kubelet" ]]; then
+              kubelet_monitoring
+            else
+              echo "Health monitoring for component ${component} is not supported!"
+            fi
+
     - path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
       content:
         inline:
@@ -277,11 +413,11 @@ spec:
             if systemctl is-active ufw; then systemctl stop ufw; fi
             systemctl mask ufw
 
-            {{- /* As we added some modules and don't want to reboot, restart the service */}}
+            {{- /* As we added some modules and don't want to reboot, restart the service */ }}
             systemctl restart systemd-modules-load.service
             sysctl --system
 
-            {{- /* Make sure we always disable swap - Otherwise the kubelet won't start'. */}}
+            {{- /* Make sure we always disable swap - Otherwise the kubelet won't start'. */ }}
             sed -i.orig '/.*swap.*/d' /etc/fstab
             swapoff -a
 
@@ -309,11 +445,11 @@ spec:
               {{- end }}
               ipvsadm
 
-            {{- template "configureProxyScript" }}
-
             {{- template "containerRuntimeInstallation" }}
 
             {{- template "safeDownloadBinariesScript" }}
+
+            {{- template "configureProxyScript" }}
 
             # set kubelet nodeip environment variable
             /opt/bin/setup_net_env.sh
@@ -366,7 +502,7 @@ spec:
               {{- if .ExternalCloudProvider }}
               --cloud-provider=external \
               {{- else if .InTreeCCMAvailable }}
-              --cloud-provider={{- .CloudProviderName}} \
+              --cloud-provider={{- .CloudProviderName }} \
               --cloud-config=/etc/kubernetes/cloud-config \
               {{- end }}
               {{- if ne .CloudProviderName "aws" }}
@@ -510,7 +646,7 @@ spec:
             - "{{ . }}"
             {{- end }}
             clusterDomain: cluster.local
-            {{- /* containerLogMaxSize and containerLogMaxFiles have no effect for docker  */}}
+            {{- /* containerLogMaxSize and containerLogMaxFiles have no effect for docker  */ }}
             {{- if ne .ContainerRuntime "docker" }}
             {{- if .ContainerLogMaxSize }}
             containerLogMaxSize: {{ .ContainerLogMaxSize }}

--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -40,6 +40,14 @@ spec:
               data: |
                 runtime-endpoint: unix:///run/containerd/containerd.sock
 
+        - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
         - path: "/etc/containerd/config.toml"
           permissions: 0600
           content:
@@ -62,6 +70,22 @@ spec:
 
     - name: docker
       files:
+        - path: "/etc/systemd/system/containerd.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
+        - path: "/etc/systemd/system/docker.service.d/environment.conf"
+          content:
+            inline:
+              data: |
+                [Service]
+                Restart=always
+                EnvironmentFile=-/etc/environment
+
         - path: /etc/docker/daemon.json
           permissions: 0644
           content:
@@ -199,35 +223,6 @@ spec:
       {{- end }}
 
   files:
-    - path: /etc/environment
-      content:
-        inline:
-          data: |
-            {{- if .HTTPProxy }}
-            HTTP_PROXY={{ .HTTPProxy }}
-            http_proxy={{ .HTTPProxy }}
-            HTTPS_PROXY={{ .HTTPProxy }}
-            https_proxy={{ .HTTPProxy }}
-            NO_PROXY={{ .NoProxy }}
-            no_proxy={{ .NoProxy }}
-            {{- end }}
-
-    - path: "/etc/systemd/system/containerd.service.d/environment.conf"
-      content:
-        inline:
-          data: |
-            [Service]
-            Restart=always
-            EnvironmentFile=-/etc/environment
-
-    - path: "/etc/systemd/system/docker.service.d/environment.conf"
-      content:
-        inline:
-          data: |
-            [Service]
-            Restart=always
-            EnvironmentFile=-/etc/environment
-
     - path: "/opt/bin/health-monitor.sh"
       permissions: 0755
       content:


### PR DESCRIPTION
**What this PR does / why we need it**:

* inline /opt/bin/health-monitor.sh script instead of downloading it from internet
* use directives to write files instead of inline bash
* consistent spacing around `{{` and `}}` of Go templates
* chmod 600 /etc/containerd/config.toml (as it MAY contain auth information)

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Refactor OSP templates
```
