### PR TITLE
Domain name is not required when using application credentials

### DIFF
--- a/pkg/cloudprovider/openstack/types/cloudconfig.go
+++ b/pkg/cloudprovider/openstack/types/cloudconfig.go
@@ -40,8 +40,8 @@ username    = {{ .Global.Username | iniEscape }}
 password    = {{ .Global.Password | iniEscape }}
 tenant-name = {{ .Global.ProjectName | iniEscape }}
 tenant-id   = {{ .Global.ProjectID | iniEscape }}
-{{- end }}
 domain-name = {{ .Global.DomainName | iniEscape }}
+{{- end }}
 region      = {{ .Global.Region | iniEscape }}
 
 [LoadBalancer]

--- a/pkg/cloudprovider/openstack/types/cloudconfig_test.go
+++ b/pkg/cloudprovider/openstack/types/cloudconfig_test.go
@@ -54,7 +54,6 @@ func TestCloudConfigToString(t *testing.T) {
 auth-url    = "https://test"
 application-credential-id     = "redacted"
 application-credential-secret = "redacted"
-domain-name = "domain"
 region      = "unknown"
 
 [LoadBalancer]


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Domain name is not required when using application credentials.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
xref https://github.com/kubermatic/kubeone/issues/1872
