### PR TITLE
Disable firewalld on supported OSes

### DIFF
--- a/deploy/osps/default/osp-amzn2.yaml
+++ b/deploy/osps/default/osp-amzn2.yaml
@@ -423,6 +423,8 @@ spec:
               {{- end }}
               ipvsadm
 
+            systemctl disable --now firewalld || true
+
             {{- template "containerRuntimeInstallation" }}
 
             {{- template "safeDownloadBinariesScript" }}

--- a/deploy/osps/default/osp-centos.yaml
+++ b/deploy/osps/default/osp-centos.yaml
@@ -444,6 +444,8 @@ spec:
               {{- end }}
               ipvsadm
 
+            systemctl disable --now firewalld || true
+
             {{- /* iscsid service is required on Nutanix machines for CSI driver to attach volumes. */ }}
             {{- if eq .CloudProviderName "nutanix" }}
             systemctl enable --now iscsid

--- a/deploy/osps/default/osp-centos8.yaml
+++ b/deploy/osps/default/osp-centos8.yaml
@@ -448,6 +448,8 @@ spec:
               {{- end }}
               ipvsadm
 
+            systemctl disable --now firewalld || true
+
             {{- /* iscsid service is required on Nutanix machines for CSI driver to attach volumes. */ }}
             {{- if eq .CloudProviderName "nutanix" }}
             systemctl enable --now iscsid

--- a/deploy/osps/default/osp-rhel.yaml
+++ b/deploy/osps/default/osp-rhel.yaml
@@ -424,12 +424,6 @@ spec:
 
             {{ if eq .CloudProviderName "azure" }}
             yum update -y --disablerepo='*' --enablerepo='*microsoft*'
-            firewall-cmd --permanent --zone=trusted --add-source={{ .PodCIDR }}
-            firewall-cmd --permanent --add-port=8472/udp
-            firewall-cmd --permanent --add-port={{ .NodePortRange }}/tcp
-            firewall-cmd --permanent --add-port={{ .NodePortRange }}/udp
-            firewall-cmd --reload
-            systemctl restart firewalld
             {{ end }}
             yum install -y \
               device-mapper-persistent-data \

--- a/deploy/osps/default/osp-rhel.yaml
+++ b/deploy/osps/default/osp-rhel.yaml
@@ -450,6 +450,8 @@ spec:
               {{- end }}
               ipvsadm
 
+            systemctl disable --now firewalld || true
+
             {{- /* iscsid service is required on Nutanix machines for CSI driver to attach volumes. */ }}
             {{- if eq .CloudProviderName "nutanix" }}
             systemctl enable --now iscsid


### PR DESCRIPTION
**What this PR does / why we need it**:
Out of context (i.e. not kubernetes aware iptables operations) ip filtering is fundamentally incompatible with the Kubernetes. Network resources should be protect by the cloud security groups or network policies (or both!).

XRef: https://github.com/kubermatic/kubermatic/issues/8768

```release-note
Disable firewalld on supported OSes
```
