### PR TITLE
Use the correct field for the external cloud provider flag

### DIFF
--- a/deploy/osps/default/osp-amzn2.yaml
+++ b/deploy/osps/default/osp-amzn2.yaml
@@ -567,7 +567,7 @@ spec:
                 --container-runtime-endpoint=unix:///var/run/dockershim.sock \
                 {{- end }}
                 {{- /* If external or in-tree CCM is in use we don't need to set --node-ip as the cloud provider will know what IPs to return.  */}}
-                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.IsExternal))) }}
+                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.ExternalCloudProvider))) }}
                 --node-ip ${KUBELET_NODE_IP}
                 {{- end }}
 

--- a/deploy/osps/default/osp-centos.yaml
+++ b/deploy/osps/default/osp-centos.yaml
@@ -603,7 +603,7 @@ spec:
                 --container-runtime-endpoint=unix:///var/run/dockershim.sock \
                 {{- end }}
                 {{- /* If external or in-tree CCM is in use we don't need to set --node-ip as the cloud provider will know what IPs to return.  */}}
-                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.IsExternal))) }}
+                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.ExternalCloudProvider))) }}
                 --node-ip ${KUBELET_NODE_IP}
                 {{- end }}
 

--- a/deploy/osps/default/osp-centos8.yaml
+++ b/deploy/osps/default/osp-centos8.yaml
@@ -607,7 +607,7 @@ spec:
                 --container-runtime-endpoint=unix:///var/run/dockershim.sock \
                 {{- end }}
                 {{- /* If external or in-tree CCM is in use we don't need to set --node-ip as the cloud provider will know what IPs to return.  */}}
-                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.IsExternal))) }}
+                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.ExternalCloudProvider))) }}
                 --node-ip ${KUBELET_NODE_IP}
                 {{- end }}
 

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -676,7 +676,7 @@ spec:
                 --container-runtime-endpoint=unix:///var/run/dockershim.sock \
                 {{- end }}
                 {{- /* If external or in-tree CCM is in use we don't need to set --node-ip as the cloud provider will know what IPs to return.  */}}
-                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.IsExternal))) }}
+                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.ExternalCloudProvider))) }}
                 --node-ip ${KUBELET_NODE_IP}
                 {{- end }}
 

--- a/deploy/osps/default/osp-rhel.yaml
+++ b/deploy/osps/default/osp-rhel.yaml
@@ -602,7 +602,7 @@ spec:
                 --container-runtime-endpoint=unix:///var/run/dockershim.sock \
                 {{- end }}
                 {{- /* If external or in-tree CCM is in use we don't need to set --node-ip as the cloud provider will know what IPs to return.  */}}
-                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.IsExternal))) }}
+                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.ExternalCloudProvider))) }}
                 --node-ip ${KUBELET_NODE_IP}
                 {{- end }}
 

--- a/deploy/osps/default/osp-rockylinux.yaml
+++ b/deploy/osps/default/osp-rockylinux.yaml
@@ -594,7 +594,7 @@ spec:
                 --container-runtime-endpoint=unix:///var/run/dockershim.sock \
                 {{- end }}
                 {{- /* If external or in-tree CCM is in use we don't need to set --node-ip as the cloud provider will know what IPs to return.  */}}
-                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.IsExternal))) }}
+                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.ExternalCloudProvider))) }}
                 --node-ip ${KUBELET_NODE_IP}
                 {{- end }}
 

--- a/deploy/osps/default/osp-sles.yaml
+++ b/deploy/osps/default/osp-sles.yaml
@@ -500,7 +500,7 @@ spec:
                 --container-runtime-endpoint=unix:///var/run/dockershim.sock \
                 {{- end }}
                 {{- /* If external or in-tree CCM is in use we don't need to set --node-ip as the cloud provider will know what IPs to return.  */}}
-                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.IsExternal))) }}
+                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.ExternalCloudProvider))) }}
                 --node-ip ${KUBELET_NODE_IP}
                 {{- end }}
 

--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -591,7 +591,7 @@ spec:
                 --container-runtime-endpoint=unix:///var/run/dockershim.sock \
                 {{- end }}
                 {{- /* If external or in-tree CCM is in use we don't need to set --node-ip as the cloud provider will know what IPs to return.  */}}
-                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.IsExternal))) }}
+                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.ExternalCloudProvider))) }}
                 --node-ip ${KUBELET_NODE_IP}
                 {{- end }}
 

--- a/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
+++ b/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
@@ -611,7 +611,7 @@ spec:
                 --container-runtime-endpoint=unix:///var/run/dockershim.sock \
                 {{- end }}
                 {{- /* If external or in-tree CCM is in use we don't need to set --node-ip as the cloud provider will know what IPs to return.  */}}
-                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.IsExternal))) }}
+                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.ExternalCloudProvider))) }}
                 --node-ip ${KUBELET_NODE_IP}
                 {{- end }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Rename a field in the default osps from `IsExternal` to `ExternalCloudProvider` as `IsExternal` doesn't exist. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None 
```
