### PR TITLE
Fix for handling dualstack and all cases for passing node-ip parameter to kubelet 

### DIFF
--- a/deploy/osps/default/osp-amzn2.yaml
+++ b/deploy/osps/default/osp-amzn2.yaml
@@ -569,7 +569,7 @@ spec:
                 --container-runtime-endpoint=unix:///var/run/dockershim.sock \
                 {{- end }}
                 {{- /* If external or in-tree CCM is in use we don't need to set --node-ip as the cloud provider will know what IPs to return.  */}}
-                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.ExternalCloudProvider))) }}
+                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.InTreeCCMAvailable) (.ExternalCloudProvider))) }}
                 --node-ip ${KUBELET_NODE_IP}
                 {{- end }}
 

--- a/deploy/osps/default/osp-centos.yaml
+++ b/deploy/osps/default/osp-centos.yaml
@@ -611,7 +611,7 @@ spec:
                 --container-runtime-endpoint=unix:///var/run/dockershim.sock \
                 {{- end }}
                 {{- /* If external or in-tree CCM is in use we don't need to set --node-ip as the cloud provider will know what IPs to return.  */}}
-                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.ExternalCloudProvider))) }}
+                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.InTreeCCMAvailable) (.ExternalCloudProvider))) }}
                 --node-ip ${KUBELET_NODE_IP}
                 {{- end }}
 

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -647,7 +647,7 @@ spec:
                 --container-runtime-endpoint=unix:///var/run/dockershim.sock \
                 {{- end }}
                 {{- /* If external or in-tree CCM is in use we don't need to set --node-ip as the cloud provider will know what IPs to return.  */}}
-                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.ExternalCloudProvider))) }}
+                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.InTreeCCMAvailable) (.ExternalCloudProvider))) }}
                 --node-ip ${KUBELET_NODE_IP}
                 {{- end }}
 

--- a/deploy/osps/default/osp-rhel.yaml
+++ b/deploy/osps/default/osp-rhel.yaml
@@ -609,7 +609,7 @@ spec:
                 --container-runtime-endpoint=unix:///var/run/dockershim.sock \
                 {{- end }}
                 {{- /* If external or in-tree CCM is in use we don't need to set --node-ip as the cloud provider will know what IPs to return.  */}}
-                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.ExternalCloudProvider))) }}
+                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.InTreeCCMAvailable) (.ExternalCloudProvider))) }}
                 --node-ip ${KUBELET_NODE_IP}
                 {{- end }}
 

--- a/deploy/osps/default/osp-rockylinux.yaml
+++ b/deploy/osps/default/osp-rockylinux.yaml
@@ -604,7 +604,7 @@ spec:
                 --container-runtime-endpoint=unix:///var/run/dockershim.sock \
                 {{- end }}
                 {{- /* If external or in-tree CCM is in use we don't need to set --node-ip as the cloud provider will know what IPs to return.  */}}
-                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.ExternalCloudProvider))) }}
+                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.InTreeCCMAvailable) (.ExternalCloudProvider))) }}
                 --node-ip ${KUBELET_NODE_IP}
                 {{- end }}
 

--- a/deploy/osps/default/osp-sles.yaml
+++ b/deploy/osps/default/osp-sles.yaml
@@ -506,7 +506,7 @@ spec:
                 --container-runtime-endpoint=unix:///var/run/dockershim.sock \
                 {{- end }}
                 {{- /* If external or in-tree CCM is in use we don't need to set --node-ip as the cloud provider will know what IPs to return.  */}}
-                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.ExternalCloudProvider))) }}
+                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.InTreeCCMAvailable) (.ExternalCloudProvider))) }}
                 --node-ip ${KUBELET_NODE_IP}
                 {{- end }}
 

--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -603,7 +603,7 @@ spec:
                 --container-runtime-endpoint=unix:///var/run/dockershim.sock \
                 {{- end }}
                 {{- /* If external or in-tree CCM is in use we don't need to set --node-ip as the cloud provider will know what IPs to return.  */}}
-                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.ExternalCloudProvider))) }}
+                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.InTreeCCMAvailable) (.ExternalCloudProvider))) }}
                 --node-ip ${KUBELET_NODE_IP}
                 {{- end }}
 

--- a/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
+++ b/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
@@ -603,7 +603,7 @@ spec:
                 --container-runtime-endpoint=unix:///var/run/dockershim.sock \
                 {{- end }}
                 {{- /* If external or in-tree CCM is in use we don't need to set --node-ip as the cloud provider will know what IPs to return.  */}}
-                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.CloudProviderName) (.ExternalCloudProvider))) }}
+                {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.InTreeCCMAvailable) (.ExternalCloudProvider))) }}
                 --node-ip ${KUBELET_NODE_IP}
                 {{- end }}
 


### PR DESCRIPTION
Signed-off-by: Sachin Tiptur <sachin@kubermatic.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time sending a pull request, please read our contributing guidelines: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md
2. Make sure *all* commits in a pull request have the DCO signoff message. Without a DCO signoff, we can't review and merge your pull request due to legal reasons. Check the contributing guidelines for more information about DCO and how to sign commits: https://github.com/OWNER/PROJECT/blob/master/CONTRIBUTING.md#certificate-of-origin
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
DigitalOcean and Equinix nodes are missing IPv6 addresses 'kubectl describe nodes' in dual stack mode.
This PR fixes this by modifying the logic in OSP yaml files while passing "--node-ip" parameter to kubelet.

_**Logic used:**_
```
Case Non-Dual-Stack:
	Always pass --node-ip

Case Dual-Stack:
 if no InTreeCCM or external cloud provider is provided 
	then pass --node-ip
 else
	then do not pass --node-ip
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #[10642](https://github.com/kubermatic/kubermatic/issues/10642)

**Special notes for your reviewer**:
Only "make test" was run to verify this fix. The actual node bring up test was not possible due to limitations.
**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
