### PR TITLE
Use resourceVersion to rotate OSCs and Secrets

### DIFF
--- a/pkg/controllers/osc/osc_controller.go
+++ b/pkg/controllers/osc/osc_controller.go
@@ -25,7 +25,6 @@ import (
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/containerruntime"
-	machinecontrollerutil "github.com/kubermatic/machine-controller/pkg/controller/util"
 	"k8c.io/operating-system-manager/pkg/bootstrap"
 	"k8c.io/operating-system-manager/pkg/controllers/osc/resources"
 	osmv1alpha1 "k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1"
@@ -256,7 +255,7 @@ func (r *Reconciler) reconcileOperatingSystemConfigs(ctx context.Context, md *cl
 	}
 
 	// Add machine deployment revision to OSC
-	revision := md.Annotations[machinecontrollerutil.RevisionAnnotation]
+	revision := md.ResourceVersion
 	osc.Annotations = addMachineDeploymentRevision(revision, osc.Annotations)
 
 	// Create resource in cluster
@@ -304,7 +303,7 @@ func (r *Reconciler) ensureCloudConfigSecret(ctx context.Context, config osmv1al
 	secret = resources.GenerateCloudConfigSecret(secretName, CloudInitSettingsNamespace, provisionData)
 
 	// Add machine deployment revision to secret
-	revision := md.Annotations[machinecontrollerutil.RevisionAnnotation]
+	revision := md.ResourceVersion
 	secret.Annotations = addMachineDeploymentRevision(revision, secret.Annotations)
 
 	// Create resource in cluster
@@ -393,7 +392,7 @@ func (r *Reconciler) handleOSCAndSecretRotation(ctx context.Context, md *cluster
 
 	// OSC already exists, we need to check if the template in machine deployment was updated. If it's updated then we need to rotate
 	// the OSC and secrets.
-	currentRevision := md.Annotations[machinecontrollerutil.RevisionAnnotation]
+	currentRevision := md.ResourceVersion
 	existingRevision := osc.Annotations[MachineDeploymentRevision]
 
 	if currentRevision == existingRevision {

--- a/pkg/controllers/osc/testdata/osc-flatcar-aws-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-flatcar-aws-containerd.yaml
@@ -2,7 +2,7 @@ apiVersion: operatingsystemmanager.k8c.io/v1alpha1
 kind: OperatingSystemConfig
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: flatcar-aws-containerd-kube-system-config
   namespace: kube-system

--- a/pkg/controllers/osc/testdata/osc-flatcar-aws-docker.yaml
+++ b/pkg/controllers/osc/testdata/osc-flatcar-aws-docker.yaml
@@ -2,7 +2,7 @@ apiVersion: operatingsystemmanager.k8c.io/v1alpha1
 kind: OperatingSystemConfig
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: flatcar-aws-docker-kube-system-config
   namespace: kube-system

--- a/pkg/controllers/osc/testdata/osc-kubelet-configuration-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-kubelet-configuration-containerd.yaml
@@ -2,7 +2,7 @@ apiVersion: operatingsystemmanager.k8c.io/v1alpha1
 kind: OperatingSystemConfig
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: kubelet-configuration-kube-system-config
   namespace: kube-system

--- a/pkg/controllers/osc/testdata/osc-kubelet-configuration-docker.yaml
+++ b/pkg/controllers/osc/testdata/osc-kubelet-configuration-docker.yaml
@@ -2,7 +2,7 @@ apiVersion: operatingsystemmanager.k8c.io/v1alpha1
 kind: OperatingSystemConfig
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: kubelet-configuration-kube-system-config
   namespace: kube-system

--- a/pkg/controllers/osc/testdata/osc-rhel-8.x-azure-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-rhel-8.x-azure-containerd.yaml
@@ -2,7 +2,7 @@ apiVersion: operatingsystemmanager.k8c.io/v1alpha1
 kind: OperatingSystemConfig
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: osp-rhel-azure-kube-system-config
   namespace: kube-system

--- a/pkg/controllers/osc/testdata/osc-rhel-8.x-cloud-init-modules.yaml
+++ b/pkg/controllers/osc/testdata/osc-rhel-8.x-cloud-init-modules.yaml
@@ -2,7 +2,7 @@ apiVersion: operatingsystemmanager.k8c.io/v1alpha1
 kind: OperatingSystemConfig
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: osp-rhel-aws-kube-system-config
   namespace: kube-system

--- a/pkg/controllers/osc/testdata/osc-ubuntu-aws-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-aws-containerd.yaml
@@ -2,7 +2,7 @@ apiVersion: operatingsystemmanager.k8c.io/v1alpha1
 kind: OperatingSystemConfig
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: ubuntu-aws-kube-system-config
   namespace: kube-system

--- a/pkg/controllers/osc/testdata/osc-ubuntu-aws-docker.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-aws-docker.yaml
@@ -2,7 +2,7 @@ apiVersion: operatingsystemmanager.k8c.io/v1alpha1
 kind: OperatingSystemConfig
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: ubuntu-aws-kube-system-config
   namespace: kube-system

--- a/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack.yaml
@@ -2,7 +2,7 @@ apiVersion: operatingsystemmanager.k8c.io/v1alpha1
 kind: OperatingSystemConfig
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: ubuntu-aws-kube-system-config
   namespace: kube-system

--- a/pkg/controllers/osc/testdata/secret-flatcar-aws-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-flatcar-aws-containerd-bootstrap.yaml
@@ -5,7 +5,7 @@ immutable: true
 kind: Secret
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: flatcar-aws-containerd-kube-system-bootstrap-config
   namespace: cloud-init-settings

--- a/pkg/controllers/osc/testdata/secret-flatcar-aws-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-flatcar-aws-containerd-provisioning.yaml
@@ -5,7 +5,7 @@ immutable: true
 kind: Secret
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: flatcar-aws-containerd-kube-system-provisioning-config
   namespace: cloud-init-settings

--- a/pkg/controllers/osc/testdata/secret-flatcar-aws-docker-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-flatcar-aws-docker-bootstrap.yaml
@@ -5,7 +5,7 @@ immutable: true
 kind: Secret
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: flatcar-aws-docker-kube-system-bootstrap-config
   namespace: cloud-init-settings

--- a/pkg/controllers/osc/testdata/secret-flatcar-aws-docker-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-flatcar-aws-docker-provisioning.yaml
@@ -5,7 +5,7 @@ immutable: true
 kind: Secret
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: flatcar-aws-docker-kube-system-provisioning-config
   namespace: cloud-init-settings

--- a/pkg/controllers/osc/testdata/secret-kubelet-configuration-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-kubelet-configuration-containerd-bootstrap.yaml
@@ -5,7 +5,7 @@ immutable: true
 kind: Secret
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: kubelet-configuration-kube-system-bootstrap-config
   namespace: cloud-init-settings

--- a/pkg/controllers/osc/testdata/secret-kubelet-configuration-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-kubelet-configuration-containerd-provisioning.yaml
@@ -5,7 +5,7 @@ immutable: true
 kind: Secret
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: kubelet-configuration-kube-system-provisioning-config
   namespace: cloud-init-settings

--- a/pkg/controllers/osc/testdata/secret-kubelet-configuration-docker-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-kubelet-configuration-docker-bootstrap.yaml
@@ -5,7 +5,7 @@ immutable: true
 kind: Secret
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: kubelet-configuration-kube-system-bootstrap-config
   namespace: cloud-init-settings

--- a/pkg/controllers/osc/testdata/secret-kubelet-configuration-docker-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-kubelet-configuration-docker-provisioning.yaml
@@ -5,7 +5,7 @@ immutable: true
 kind: Secret
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: kubelet-configuration-kube-system-provisioning-config
   namespace: cloud-init-settings

--- a/pkg/controllers/osc/testdata/secret-osc-rhel-8.x-cloud-init-modules-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-osc-rhel-8.x-cloud-init-modules-bootstrap.yaml
@@ -5,7 +5,7 @@ immutable: true
 kind: Secret
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: osp-rhel-aws-kube-system-bootstrap-config
   namespace: cloud-init-settings

--- a/pkg/controllers/osc/testdata/secret-osc-rhel-8.x-cloud-init-modules-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-osc-rhel-8.x-cloud-init-modules-provisioning.yaml
@@ -5,7 +5,7 @@ immutable: true
 kind: Secret
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: osp-rhel-aws-kube-system-provisioning-config
   namespace: cloud-init-settings

--- a/pkg/controllers/osc/testdata/secret-rhel-8.x-azure-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-rhel-8.x-azure-containerd-bootstrap.yaml
@@ -5,7 +5,7 @@ immutable: true
 kind: Secret
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: osp-rhel-azure-kube-system-bootstrap-config
   namespace: cloud-init-settings

--- a/pkg/controllers/osc/testdata/secret-rhel-8.x-azure-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-rhel-8.x-azure-containerd-provisioning.yaml
@@ -5,7 +5,7 @@ immutable: true
 kind: Secret
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: osp-rhel-azure-kube-system-provisioning-config
   namespace: cloud-init-settings

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-containerd-bootstrap.yaml
@@ -5,7 +5,7 @@ immutable: true
 kind: Secret
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: ubuntu-aws-kube-system-bootstrap-config
   namespace: cloud-init-settings

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-containerd-provisioning.yaml
@@ -5,7 +5,7 @@ immutable: true
 kind: Secret
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: ubuntu-aws-kube-system-provisioning-config
   namespace: cloud-init-settings

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-docker-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-docker-bootstrap.yaml
@@ -5,7 +5,7 @@ immutable: true
 kind: Secret
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: ubuntu-aws-kube-system-bootstrap-config
   namespace: cloud-init-settings

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-docker-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-docker-provisioning.yaml
@@ -5,7 +5,7 @@ immutable: true
 kind: Secret
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: ubuntu-aws-kube-system-provisioning-config
   namespace: cloud-init-settings

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-bootstrap.yaml
@@ -5,7 +5,7 @@ immutable: true
 kind: Secret
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: ubuntu-aws-kube-system-bootstrap-config
   namespace: cloud-init-settings

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-provisioning.yaml
@@ -5,7 +5,7 @@ immutable: true
 kind: Secret
 metadata:
   annotations:
-    k8c.io/machine-deployment-revision: "1"
+    k8c.io/machine-deployment-revision: ""
   creationTimestamp: null
   name: ubuntu-aws-kube-system-provisioning-config
   namespace: cloud-init-settings


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we rely on the `machinedeployment.clusters.k8s.io/revision` annotation in order to trigger an update and rotate the OperatingSystemConfigs and Secrets, unfortunately this would fail in different cases, such as scaling the machines down and up again. Using the `resourceVersion` would make sure that any changes to the machine deployment would lead to the rotation. 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
