### PR TITLE
remove KubeletCloudProviderConfig func

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -56,21 +56,3 @@ func GetCloudConfig(pconfig providerconfigtypes.Config, kubeletVersion string) (
 
 	return "", errors.New("unknown cloud provider")
 }
-
-func KubeletCloudProviderConfig(cloudProvider providerconfigtypes.CloudProvider) (inTreeCCM bool, external bool, err error) {
-	switch osmv1alpha1.CloudProvider(cloudProvider) {
-	case osmv1alpha1.CloudProviderAWS, osmv1alpha1.CloudProviderAzure, osmv1alpha1.CloudProviderGoogle,
-		osmv1alpha1.CloudProviderOpenstack, osmv1alpha1.CloudProviderVsphere:
-		return true, false, nil
-
-	case osmv1alpha1.CloudProviderKubeVirt:
-		return false, true, nil
-
-	case osmv1alpha1.CloudProviderAlibaba, osmv1alpha1.CloudProviderAnexia, osmv1alpha1.CloudProviderDigitalocean,
-		osmv1alpha1.CloudProviderHetzner, osmv1alpha1.CloudProviderLinode, osmv1alpha1.CloudProviderEquinixMetal,
-		osmv1alpha1.CloudProviderScaleway, osmv1alpha1.CloudProviderNutanix, osmv1alpha1.CloudProviderVMwareCloudDirector:
-		return false, false, nil
-	}
-
-	return false, false, errors.New("unknown cloud provider")
-}

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -56,3 +56,21 @@ func GetCloudConfig(pconfig providerconfigtypes.Config, kubeletVersion string) (
 
 	return "", errors.New("unknown cloud provider")
 }
+
+func KubeletCloudProviderConfig(cloudProvider providerconfigtypes.CloudProvider, external bool) (inTreeCCM bool, outOfTree bool, err error) {
+	switch osmv1alpha1.CloudProvider(cloudProvider) {
+	case osmv1alpha1.CloudProviderAWS, osmv1alpha1.CloudProviderAzure,
+		osmv1alpha1.CloudProviderOpenstack, osmv1alpha1.CloudProviderVsphere:
+		if external {
+			return false, true, nil
+		}
+
+		return true, false, nil
+
+	case osmv1alpha1.CloudProviderGoogle:
+		return true, false, nil
+
+	default:
+		return false, external, nil
+	}
+}

--- a/pkg/controllers/osc/resources/operating_system_config.go
+++ b/pkg/controllers/osc/resources/operating_system_config.go
@@ -171,10 +171,9 @@ func GenerateOperatingSystemConfig(
 		BootstrapKubeconfigSecretName: bootstrapKubeconfigSecretName,
 	}
 
-	var inTreeCCM bool
-	if !externalCloudProvider &&
-		osmv1alpha1.CloudProvider(providerConfig.CloudProvider) == osmv1alpha1.CloudProviderGoogle {
-		inTreeCCM = true
+	inTreeCCM, external, err := cloudprovider.KubeletCloudProviderConfig(providerConfig.CloudProvider, externalCloudProvider)
+	if err != nil {
+		return nil, err
 	}
 
 	data := filesData{
@@ -185,7 +184,7 @@ func GenerateOperatingSystemConfig(
 		CloudConfig:                cloudConfig,
 		ContainerRuntime:           containerRuntime,
 		CloudProviderName:          osmv1alpha1.CloudProvider(providerConfig.CloudProvider),
-		ExternalCloudProvider:      externalCloudProvider,
+		ExternalCloudProvider:      external,
 		PauseImage:                 pauseImage,
 		InitialTaints:              initialTaints,
 		ContainerRuntimeConfig:     crConfig,

--- a/pkg/controllers/osc/resources/operating_system_config.go
+++ b/pkg/controllers/osc/resources/operating_system_config.go
@@ -127,11 +127,6 @@ func GenerateOperatingSystemConfig(
 		kubeletVersionStr = fmt.Sprintf("v%s", kubeletVersionStr)
 	}
 
-	inTreeCCM, external, err := cloudprovider.KubeletCloudProviderConfig(providerConfig.CloudProvider)
-	if err != nil {
-		return nil, err
-	}
-
 	// Handling for kubelet configuration
 	kubeletConfigs, err := getKubeletConfigs(md.Annotations)
 	if err != nil {
@@ -156,10 +151,6 @@ func GenerateOperatingSystemConfig(
 		return nil, fmt.Errorf("failed to generate container runtime auth config: %w", err)
 	}
 
-	if external {
-		externalCloudProvider = true
-	}
-
 	bootstrapKubeconfigString, err := kubeconfigutil.StringifyKubeconfig(bootstrapKubeconfig)
 	if err != nil {
 		return nil, err
@@ -178,6 +169,12 @@ func GenerateOperatingSystemConfig(
 		SecretName:                    provisioningSecretName,
 		ServerURL:                     serverURL,
 		BootstrapKubeconfigSecretName: bootstrapKubeconfigSecretName,
+	}
+
+	var inTreeCCM bool
+	if !externalCloudProvider &&
+		osmv1alpha1.CloudProvider(providerConfig.CloudProvider) == osmv1alpha1.CloudProviderGoogle {
+		inTreeCCM = true
 	}
 
 	data := filesData{


### PR DESCRIPTION
**What this PR does / why we need it**:
We send whether the used cloud provider is external or internal as a flag. `KubeletCloudProviderConfig` configures thing in a very wrong way thus we don't need it anymore. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Rely only on `external-cloud-provider` flag instead of overriding the value by `KubeletCloudProviderConfig` 
````

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
