### PR TITLE
Add missing check that only sets OSP annotation on MachineDeployments if it's unset

### DIFF
--- a/pkg/admission/machinedeployment/mutation/mutation.go
+++ b/pkg/admission/machinedeployment/mutation/mutation.go
@@ -96,22 +96,26 @@ func MutateMachineDeployment(md *clusterv1alpha1.MachineDeployment) error {
 		return fmt.Errorf("failed to read MachineDeployment.Spec.Template.Spec.ProviderSpec: %w", err)
 	}
 
-	if md.Annotations == nil {
-		md.Annotations = make(map[string]string)
-	}
+	// Check for existing annotation if it doesn't exist or if the value is empty
+	// inject the appropriate annotation.
+	if val, ok := md.Annotations[resources.MachineDeploymentOSPAnnotation]; !ok || val == "" {
+		if md.Annotations == nil {
+			md.Annotations = make(map[string]string)
+		}
 
-	switch providerConfig.OperatingSystem {
-	case providerconfigtypes.OperatingSystemUbuntu,
-		providerconfigtypes.OperatingSystemCentOS,
-		providerconfigtypes.OperatingSystemFlatcar,
-		providerconfigtypes.OperatingSystemAmazonLinux2,
-		providerconfigtypes.OperatingSystemRockyLinux,
-		providerconfigtypes.OperatingSystemSLES,
-		providerconfigtypes.OperatingSystemRHEL:
+		switch providerConfig.OperatingSystem {
+		case providerconfigtypes.OperatingSystemUbuntu,
+			providerconfigtypes.OperatingSystemCentOS,
+			providerconfigtypes.OperatingSystemFlatcar,
+			providerconfigtypes.OperatingSystemAmazonLinux2,
+			providerconfigtypes.OperatingSystemRockyLinux,
+			providerconfigtypes.OperatingSystemSLES,
+			providerconfigtypes.OperatingSystemRHEL:
 
-		md.Annotations[resources.MachineDeploymentOSPAnnotation] = fmt.Sprintf(ospNamePattern, providerConfig.OperatingSystem)
-	default:
-		return fmt.Errorf("failed to populate OSP annotation for machinedeployment with unsupported Operating System %s", providerConfig.OperatingSystem)
+			md.Annotations[resources.MachineDeploymentOSPAnnotation] = fmt.Sprintf(ospNamePattern, providerConfig.OperatingSystem)
+		default:
+			return fmt.Errorf("failed to populate OSP annotation for machinedeployment with unsupported Operating System %s", providerConfig.OperatingSystem)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

When porting the OSP annotation mutation for MachineDeployments I forgot to include this if condition.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
