### PR TITLE
Hotfix: CA Bundle flag

### DIFF
--- a/cmd/osm-controller/main.go
+++ b/cmd/osm-controller/main.go
@@ -254,7 +254,7 @@ func main() {
 	}
 
 	caCert := customCACert
-	if customCACert != "" {
+	if opt.caBundleFile == "" {
 		caCert, err = certificate.GetCACert(opt.kubeconfig, mgr.GetConfig())
 		if err != nil {
 			klog.Fatal("failed to load CA certificate", zap.Error(err))


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
```
https://github.com/kubermatic/operating-system-manager/pull/237 broke OSM

Nov 14 08:56:51 ip-172-31-252-196 kubelet[6832]: Error: failed to construct kubelet dependencies: unable to load client CA file /etc/kubernetes/pki/ca.crt: error creating pool from /etc/kubernetes/pki/ca.crt: data does not con>
root@ip-172-31-252-196:~# cat /etc/kubernetes/pki/ca.crt
kubelet fails to start now because the file is empty
```

From @embik 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
