### PR TITLE
Pin containerd to v1.6 for Amazon Linux

### DIFF
--- a/deploy/osps/default/osp-amzn2.yaml
+++ b/deploy/osps/default/osp-amzn2.yaml
@@ -129,9 +129,8 @@ spec:
                   {{ .ContainerRuntimeConfig }}
         templates:
           containerRuntimeInstallation: |-
-            {{- /* Amazon Linux 2 does not have containerd 1.5 support */}}
             yum install -y \
-              containerd-1.4* \
+              containerd-1.6* \
               yum-plugin-versionlock
             yum versionlock add containerd
 


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
Amzn2 images have been updated upstream and they now support containerd 1.6; previously this was a limitation and we had to pin it to v1.4. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Upgrade containerd to v1.6 for Amazon Linux
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
