### PR TITLE
Add new CRD for CustomOperatingSystemProfile

### DIFF
--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -58,7 +58,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.19.4
+        - image: quay.io/kubermatic/build:go-1.19-node-18-5
           command:
             - make
           args:

--- a/hack/kkp/operatingsystemmanager.k8c.io_customoperatingsystemprofiles.yaml
+++ b/hack/kkp/operatingsystemmanager.k8c.io_customoperatingsystemprofiles.yaml
@@ -1,0 +1,442 @@
+# Copyright 2023 The Operating System Manager contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: customoperatingsystemprofiles.operatingsystemmanager.k8c.io
+spec:
+  group: operatingsystemmanager.k8c.io
+  names:
+    kind: CustomOperatingSystemProfile
+    listKind: CustomOperatingSystemProfileList
+    plural: customoperatingsystemprofiles
+    shortNames:
+      - cosp
+    singular: customoperatingsystemprofile
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: OperatingSystemProfile is the object that represents the OperatingSystemProfile
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: OperatingSystemProfileSpec represents the operating system configuration spec.
+              properties:
+                bootstrapConfig:
+                  description: BootstrapConfig is used for initial configuration of machine and to fetch the kubernetes secret that contains the provisioning config.
+                  properties:
+                    files:
+                      description: Files is a list of files that should exist in the instance
+                      items:
+                        description: File is a file that should get written to the host's file system. The content can either be inlined or referenced from a secret in the same namespace.
+                        properties:
+                          content:
+                            description: Content describe the file's content.
+                            properties:
+                              inline:
+                                description: Inline is a struct that contains information about the inlined data.
+                                properties:
+                                  data:
+                                    description: Data is the file's data.
+                                    type: string
+                                  encoding:
+                                    description: Encoding is the file's encoding (e.g. base64).
+                                    type: string
+                                required:
+                                  - data
+                                type: object
+                            type: object
+                          path:
+                            description: Path is the path of the file system where the file should get written to.
+                            type: string
+                          permissions:
+                            default: 644
+                            description: Permissions describes with which permissions the file should get written to the file system. Should be in decimal base and without any leading zeroes.
+                            format: int32
+                            type: integer
+                        required:
+                          - content
+                          - path
+                        type: object
+                      type: array
+                    modules:
+                      description: CloudInitModules field contains the optional cloud-init modules which are supported by OSM
+                      properties:
+                        bootcmd:
+                          description: BootCMD module runs arbitrary commands very early in the boot process, only slightly after a boothook would run.
+                          items:
+                            type: string
+                          type: array
+                        rh_subscription:
+                          additionalProperties:
+                            type: string
+                          description: RHSubscription registers a Red Hat system either by username and password or activation and org
+                          type: object
+                        runcmd:
+                          description: RunCMD Run arbitrary commands at a rc.local like level with output to the console.
+                          items:
+                            type: string
+                          type: array
+                        yum_repo_dir:
+                          description: 'YumRepoDir the repo parts directory where individual yum repo config files will be written. Default: /etc/yum.repos.d'
+                          type: string
+                        yum_repos:
+                          additionalProperties:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          description: YumRepos adds yum repository configuration to the system.
+                          type: object
+                      type: object
+                    supportedContainerRuntimes:
+                      description: SupportedContainerRuntimes represents the container runtimes supported by the given OS
+                      items:
+                        description: ContainerRuntimeSpec aggregates information about a specific container runtime
+                        properties:
+                          files:
+                            description: Files to add to the main files list when the containerRuntime is selected
+                            items:
+                              description: File is a file that should get written to the host's file system. The content can either be inlined or referenced from a secret in the same namespace.
+                              properties:
+                                content:
+                                  description: Content describe the file's content.
+                                  properties:
+                                    inline:
+                                      description: Inline is a struct that contains information about the inlined data.
+                                      properties:
+                                        data:
+                                          description: Data is the file's data.
+                                          type: string
+                                        encoding:
+                                          description: Encoding is the file's encoding (e.g. base64).
+                                          type: string
+                                      required:
+                                        - data
+                                      type: object
+                                  type: object
+                                path:
+                                  description: Path is the path of the file system where the file should get written to.
+                                  type: string
+                                permissions:
+                                  default: 644
+                                  description: Permissions describes with which permissions the file should get written to the file system. Should be in decimal base and without any leading zeroes.
+                                  format: int32
+                                  type: integer
+                              required:
+                                - content
+                                - path
+                              type: object
+                            type: array
+                          name:
+                            description: Name of the Container runtime
+                            enum:
+                              - docker
+                              - containerd
+                            type: string
+                          templates:
+                            additionalProperties:
+                              type: string
+                            description: Templates to add to the available templates when the containerRuntime is selected
+                            type: object
+                        required:
+                          - files
+                          - name
+                        type: object
+                      type: array
+                    templates:
+                      additionalProperties:
+                        type: string
+                      description: Templates to be included in units and files
+                      type: object
+                    units:
+                      description: Units a list of the systemd unit files which will run on the instance
+                      items:
+                        description: Unit is a systemd unit used for the operating system config.
+                        properties:
+                          content:
+                            description: Content is the unit's content.
+                            type: string
+                          dropIns:
+                            description: DropIns is a list of drop-ins for this unit.
+                            items:
+                              description: DropIn is a drop-in configuration for a systemd unit.
+                              properties:
+                                content:
+                                  description: Content is the content of the drop-in.
+                                  type: string
+                                name:
+                                  description: Name is the name of the drop-in.
+                                  type: string
+                              required:
+                                - content
+                                - name
+                              type: object
+                            type: array
+                          enable:
+                            description: Enable describes whether the unit is enabled or not.
+                            type: boolean
+                          mask:
+                            description: Mask describes whether the unit is masked or not.
+                            type: boolean
+                          name:
+                            description: Name is the name of a unit.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                  type: object
+                osName:
+                  description: 'OSType represent the operating system name e.g: ubuntu'
+                  enum:
+                    - flatcar
+                    - rhel
+                    - centos
+                    - ubuntu
+                    - amzn2
+                    - rockylinux
+                  type: string
+                osVersion:
+                  description: OSVersion the version of the operating system
+                  type: string
+                provisioningConfig:
+                  description: ProvisioningConfig is used for provisioning the worker node.
+                  properties:
+                    files:
+                      description: Files is a list of files that should exist in the instance
+                      items:
+                        description: File is a file that should get written to the host's file system. The content can either be inlined or referenced from a secret in the same namespace.
+                        properties:
+                          content:
+                            description: Content describe the file's content.
+                            properties:
+                              inline:
+                                description: Inline is a struct that contains information about the inlined data.
+                                properties:
+                                  data:
+                                    description: Data is the file's data.
+                                    type: string
+                                  encoding:
+                                    description: Encoding is the file's encoding (e.g. base64).
+                                    type: string
+                                required:
+                                  - data
+                                type: object
+                            type: object
+                          path:
+                            description: Path is the path of the file system where the file should get written to.
+                            type: string
+                          permissions:
+                            default: 644
+                            description: Permissions describes with which permissions the file should get written to the file system. Should be in decimal base and without any leading zeroes.
+                            format: int32
+                            type: integer
+                        required:
+                          - content
+                          - path
+                        type: object
+                      type: array
+                    modules:
+                      description: CloudInitModules field contains the optional cloud-init modules which are supported by OSM
+                      properties:
+                        bootcmd:
+                          description: BootCMD module runs arbitrary commands very early in the boot process, only slightly after a boothook would run.
+                          items:
+                            type: string
+                          type: array
+                        rh_subscription:
+                          additionalProperties:
+                            type: string
+                          description: RHSubscription registers a Red Hat system either by username and password or activation and org
+                          type: object
+                        runcmd:
+                          description: RunCMD Run arbitrary commands at a rc.local like level with output to the console.
+                          items:
+                            type: string
+                          type: array
+                        yum_repo_dir:
+                          description: 'YumRepoDir the repo parts directory where individual yum repo config files will be written. Default: /etc/yum.repos.d'
+                          type: string
+                        yum_repos:
+                          additionalProperties:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          description: YumRepos adds yum repository configuration to the system.
+                          type: object
+                      type: object
+                    supportedContainerRuntimes:
+                      description: SupportedContainerRuntimes represents the container runtimes supported by the given OS
+                      items:
+                        description: ContainerRuntimeSpec aggregates information about a specific container runtime
+                        properties:
+                          files:
+                            description: Files to add to the main files list when the containerRuntime is selected
+                            items:
+                              description: File is a file that should get written to the host's file system. The content can either be inlined or referenced from a secret in the same namespace.
+                              properties:
+                                content:
+                                  description: Content describe the file's content.
+                                  properties:
+                                    inline:
+                                      description: Inline is a struct that contains information about the inlined data.
+                                      properties:
+                                        data:
+                                          description: Data is the file's data.
+                                          type: string
+                                        encoding:
+                                          description: Encoding is the file's encoding (e.g. base64).
+                                          type: string
+                                      required:
+                                        - data
+                                      type: object
+                                  type: object
+                                path:
+                                  description: Path is the path of the file system where the file should get written to.
+                                  type: string
+                                permissions:
+                                  default: 644
+                                  description: Permissions describes with which permissions the file should get written to the file system. Should be in decimal base and without any leading zeroes.
+                                  format: int32
+                                  type: integer
+                              required:
+                                - content
+                                - path
+                              type: object
+                            type: array
+                          name:
+                            description: Name of the Container runtime
+                            enum:
+                              - docker
+                              - containerd
+                            type: string
+                          templates:
+                            additionalProperties:
+                              type: string
+                            description: Templates to add to the available templates when the containerRuntime is selected
+                            type: object
+                        required:
+                          - files
+                          - name
+                        type: object
+                      type: array
+                    templates:
+                      additionalProperties:
+                        type: string
+                      description: Templates to be included in units and files
+                      type: object
+                    units:
+                      description: Units a list of the systemd unit files which will run on the instance
+                      items:
+                        description: Unit is a systemd unit used for the operating system config.
+                        properties:
+                          content:
+                            description: Content is the unit's content.
+                            type: string
+                          dropIns:
+                            description: DropIns is a list of drop-ins for this unit.
+                            items:
+                              description: DropIn is a drop-in configuration for a systemd unit.
+                              properties:
+                                content:
+                                  description: Content is the content of the drop-in.
+                                  type: string
+                                name:
+                                  description: Name is the name of the drop-in.
+                                  type: string
+                              required:
+                                - content
+                                - name
+                              type: object
+                            type: array
+                          enable:
+                            description: Enable describes whether the unit is enabled or not.
+                            type: boolean
+                          mask:
+                            description: Mask describes whether the unit is masked or not.
+                            type: boolean
+                          name:
+                            description: Name is the name of a unit.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                  type: object
+                supportedCloudProviders:
+                  description: SupportedCloudProviders represent the cloud providers that support the given operating system version
+                  items:
+                    description: CloudProviderSpec contains the os/image reference for a specific supported cloud provider
+                    properties:
+                      name:
+                        description: Name represents the name of the supported cloud provider
+                        enum:
+                          - aws
+                          - azure
+                          - digitalocean
+                          - gce
+                          - hetzner
+                          - kubevirt
+                          - linode
+                          - nutanix
+                          - openstack
+                          - equinixmetal
+                          - vsphere
+                          - fake
+                          - alibaba
+                          - anexia
+                          - scaleway
+                          - baremetal
+                          - external
+                          - vmware-cloud-director
+                        type: string
+                      spec:
+                        description: Spec represents the os/image reference in the supported cloud provider
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    required:
+                      - name
+                    type: object
+                  type: array
+                version:
+                  description: Version is the version of the operating System Profile
+                  pattern: v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+                  type: string
+              required:
+                - bootstrapConfig
+                - osName
+                - osVersion
+                - provisioningConfig
+                - supportedCloudProviders
+                - version
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true

--- a/hack/update-crds-openapi.sh
+++ b/hack/update-crds-openapi.sh
@@ -31,3 +31,7 @@ go run sigs.k8s.io/controller-tools/cmd/controller-gen \
   object:headerFile="hack/header.txt" \
   paths=./pkg/crd/... \
   output:crd:artifacts:config=./deploy/crd
+
+echodate "Generating CustomOperatingSystemProfile CRD"
+CUSTOM_OSP=./hack/kkp/operatingsystemmanager.k8c.io_customoperatingsystemprofiles.yaml
+yq -e -i '.spec.versions = load("./deploy/crd/operatingsystemmanager.k8c.io_operatingsystemprofiles.yaml").spec.versions' $CUSTOM_OSP


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
Introducing new CRD for `CustomOperatingSystemProfile`. This CRD has intentionally been placed in the `hack/kkp` directory instead of the standard `deploy/crd` directory since this serves a very special case in KKP and is not required otherwise.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
