### PR TITLE
[release/v0.3] Update containerd, docker, kubernetes-cni, and cri-tools

### DIFF
--- a/deploy/osps/default/osp-amzn2.yaml
+++ b/deploy/osps/default/osp-amzn2.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "amzn2"
   osVersion: "2.0"
-  version: "v0.1.0"
+  version: "v0.1.1"
   supportedCloudProviders:
     - name: "aws"
   supportedContainerRuntimes:
@@ -64,7 +64,7 @@ spec:
           EOF
 
           yum install -y \
-          	containerd-1.4* \
+          	containerd-1.6* \
           	yum-plugin-versionlock
           yum versionlock add containerd
 
@@ -91,8 +91,8 @@ spec:
           EOF
 
           yum install -y \
-              containerd-1.4* \
-              docker-19.03* \
+              containerd-1.6* \
+              docker-20.10* \
               yum-plugin-versionlock
           yum versionlock add docker containerd
 
@@ -128,7 +128,7 @@ spec:
       fi
 
       {{- /* # CNI variables */}}
-      CNI_VERSION="${CNI_VERSION:-v0.8.7}"
+      CNI_VERSION="${CNI_VERSION:-v1.2.0}"
       cni_base_url="https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION"
       cni_filename="cni-plugins-linux-$arch-$CNI_VERSION.tgz"
 
@@ -148,7 +148,7 @@ spec:
       cd -
 
       {{- /* # cri-tools variables */}}
-      CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.22.0}"
+      CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.26.0}"
       cri_tools_base_url="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}"
       cri_tools_filename="crictl-${CRI_TOOLS_RELEASE}-linux-${arch}.tar.gz"
 
@@ -156,8 +156,9 @@ spec:
       curl -Lfo "$opt_bin/$cri_tools_filename" "$cri_tools_base_url/$cri_tools_filename"
 
       {{- /* download cri-tools checksum */}}
-      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */}}
-      cri_tools_sum=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256" | sed 's/\*\///')
+      {{- /* the cri-tools checksum file provides only the checksum without the file name, so we need to handle it specially */}}
+      cri_tools_sum_value=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256")
+      cri_tools_sum="$cri_tools_sum_value $cri_tools_filename"
       cd "$opt_bin"
 
       {{- /* verify cri-tools checksum */}}

--- a/deploy/osps/default/osp-centos.yaml
+++ b/deploy/osps/default/osp-centos.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "centos"
   osVersion: "7.7"
-  version: "v0.1.0"
+  version: "v0.1.1"
   supportedCloudProviders:
     - name: "aws"
     - name: "azure"
@@ -77,7 +77,7 @@ spec:
           EnvironmentFile=-/etc/environment
           EOF
 
-          yum install -y containerd.io-1.4* yum-plugin-versionlock
+          yum install -y containerd.io-1.6* yum-plugin-versionlock
           yum versionlock add containerd.io
 
           systemctl daemon-reload
@@ -107,9 +107,9 @@ spec:
           EOF
 
           yum install -y \
-              docker-ce-cli-19.03* \
-              containerd.io-1.4* \
-              docker-ce-19.03* \
+              docker-ce-cli-20.10* \
+              containerd.io-1.6* \
+              docker-ce-20.10* \
               yum-plugin-versionlock
           yum versionlock add docker-ce* containerd.io
 
@@ -145,7 +145,7 @@ spec:
       fi
 
       {{- /* # CNI variables */}}
-      CNI_VERSION="${CNI_VERSION:-v0.8.7}"
+      CNI_VERSION="${CNI_VERSION:-v1.2.0}"
       cni_base_url="https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION"
       cni_filename="cni-plugins-linux-$arch-$CNI_VERSION.tgz"
 
@@ -165,7 +165,7 @@ spec:
       cd -
 
       {{- /* # cri-tools variables */}}
-      CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.22.0}"
+      CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.26.0}"
       cri_tools_base_url="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}"
       cri_tools_filename="crictl-${CRI_TOOLS_RELEASE}-linux-${arch}.tar.gz"
 
@@ -173,8 +173,9 @@ spec:
       curl -Lfo "$opt_bin/$cri_tools_filename" "$cri_tools_base_url/$cri_tools_filename"
 
       {{- /* download cri-tools checksum */}}
-      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */}}
-      cri_tools_sum=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256" | sed 's/\*\///')
+      {{- /* the cri-tools checksum file provides only the checksum without the file name, so we need to handle it specially */}}
+      cri_tools_sum_value=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256")
+      cri_tools_sum="$cri_tools_sum_value $cri_tools_filename"
       cd "$opt_bin"
 
       {{- /* verify cri-tools checksum */}}

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -21,7 +21,7 @@ spec:
   osName: flatcar
   ## Flatcar Stable (09/11/2021)
   osVersion: "2983.2.0"
-  version: "v0.1.0"
+  version: "v0.1.1"
   supportedCloudProviders:
     - name: aws
     - name: azure
@@ -115,7 +115,7 @@ spec:
       fi
 
       {{- /* # CNI variables */}}
-      CNI_VERSION="${CNI_VERSION:-v0.8.7}"
+      CNI_VERSION="${CNI_VERSION:-v1.2.0}"
       cni_base_url="https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION"
       cni_filename="cni-plugins-linux-$arch-$CNI_VERSION.tgz"
 
@@ -135,7 +135,7 @@ spec:
       cd -
 
       {{- /* # cri-tools variables */}}
-      CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.22.0}"
+      CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.26.0}"
       cri_tools_base_url="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}"
       cri_tools_filename="crictl-${CRI_TOOLS_RELEASE}-linux-${arch}.tar.gz"
 
@@ -143,8 +143,9 @@ spec:
       curl -Lfo "$opt_bin/$cri_tools_filename" "$cri_tools_base_url/$cri_tools_filename"
 
       {{- /* download cri-tools checksum */}}
-      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */}}
-      cri_tools_sum=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256" | sed 's/\*\///')
+      {{- /* the cri-tools checksum file provides only the checksum without the file name, so we need to handle it specially */}}
+      cri_tools_sum_value=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256")
+      cri_tools_sum="$cri_tools_sum_value $cri_tools_filename"
       cd "$opt_bin"
 
       {{- /* verify cri-tools checksum */}}

--- a/deploy/osps/default/osp-rhel.yaml
+++ b/deploy/osps/default/osp-rhel.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "rhel"
   osVersion: "8.4"
-  version: "v0.1.0"
+  version: "v0.1.1"
   supportedCloudProviders:
     - name: "aws"
     - name: "azure"
@@ -74,7 +74,7 @@ spec:
           EnvironmentFile=-/etc/environment
           EOF
 
-          yum install -y containerd.io-1.4* yum-plugin-versionlock
+          yum install -y containerd.io-1.6* yum-plugin-versionlock
           yum versionlock add containerd.io
 
           systemctl daemon-reload
@@ -104,9 +104,9 @@ spec:
           EOF
 
           yum install -y \
-              docker-ce-cli-19.03* \
-              containerd.io-1.4* \
-              docker-ce-19.03* \
+              docker-ce-cli-20.10* \
+              containerd.io-1.6* \
+              docker-ce-20.10* \
               yum-plugin-versionlock
           yum versionlock add docker-ce* containerd.io
 
@@ -142,7 +142,7 @@ spec:
       fi
 
       {{- /* # CNI variables */}}
-      CNI_VERSION="${CNI_VERSION:-v0.8.7}"
+      CNI_VERSION="${CNI_VERSION:-v1.2.0}"
       cni_base_url="https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION"
       cni_filename="cni-plugins-linux-$arch-$CNI_VERSION.tgz"
 
@@ -162,7 +162,7 @@ spec:
       cd -
 
       {{- /* # cri-tools variables */}}
-      CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.22.0}"
+      CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.26.0}"
       cri_tools_base_url="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}"
       cri_tools_filename="crictl-${CRI_TOOLS_RELEASE}-linux-${arch}.tar.gz"
 
@@ -170,8 +170,9 @@ spec:
       curl -Lfo "$opt_bin/$cri_tools_filename" "$cri_tools_base_url/$cri_tools_filename"
 
       {{- /* download cri-tools checksum */}}
-      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */}}
-      cri_tools_sum=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256" | sed 's/\*\///')
+      {{- /* the cri-tools checksum file provides only the checksum without the file name, so we need to handle it specially */}}
+      cri_tools_sum_value=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256")
+      cri_tools_sum="$cri_tools_sum_value $cri_tools_filename"
       cd "$opt_bin"
 
       {{- /* verify cri-tools checksum */}}

--- a/deploy/osps/default/osp-sles.yaml
+++ b/deploy/osps/default/osp-sles.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: sles
   osVersion: "15-SP-1"
-  version: "v0.1.0"
+  version: "v0.1.1"
   supportedCloudProviders:
     - name: aws
   supportedContainerRuntimes:
@@ -69,7 +69,7 @@ spec:
       fi
 
       {{- /* # CNI variables */}}
-      CNI_VERSION="${CNI_VERSION:-v0.8.7}"
+      CNI_VERSION="${CNI_VERSION:-v1.2.0}"
       cni_base_url="https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION"
       cni_filename="cni-plugins-linux-$arch-$CNI_VERSION.tgz"
 
@@ -89,7 +89,7 @@ spec:
       cd -
 
       {{- /* # cri-tools variables */}}
-      CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.22.0}"
+      CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.26.0}"
       cri_tools_base_url="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}"
       cri_tools_filename="crictl-${CRI_TOOLS_RELEASE}-linux-${arch}.tar.gz"
 
@@ -97,8 +97,9 @@ spec:
       curl -Lfo "$opt_bin/$cri_tools_filename" "$cri_tools_base_url/$cri_tools_filename"
 
       {{- /* download cri-tools checksum */}}
-      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */}}
-      cri_tools_sum=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256" | sed 's/\*\///')
+      {{- /* the cri-tools checksum file provides only the checksum without the file name, so we need to handle it specially */}}
+      cri_tools_sum_value=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256")
+      cri_tools_sum="$cri_tools_sum_value $cri_tools_filename"
       cd "$opt_bin"
 
       {{- /* verify cri-tools checksum */}}

--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "ubuntu"
   osVersion: "20.04"
-  version: "v0.1.0"
+  version: "v0.1.1"
   supportedCloudProviders:
     - name: "aws"
     - name: "azure"
@@ -75,7 +75,7 @@ spec:
           EnvironmentFile=-/etc/environment
           EOF
 
-          apt-get install -y --allow-downgrades containerd.io=1.4*
+          apt-get install -y --allow-downgrades containerd.io=1.6*
           apt-mark hold containerd.io
 
           systemctl daemon-reload
@@ -106,9 +106,9 @@ spec:
           EOF
 
           apt-get install --allow-downgrades -y \
-              containerd.io=1.4* \
-              docker-ce-cli=5:19.03* \
-              docker-ce=5:19.03*
+              containerd.io=1.6* \
+              docker-ce-cli=5:20.10* \
+              docker-ce=5:20.10*
           apt-mark hold docker-ce* containerd.io
 
           systemctl daemon-reload
@@ -143,7 +143,7 @@ spec:
       fi
 
       {{- /* # CNI variables */}}
-      CNI_VERSION="${CNI_VERSION:-v0.8.7}"
+      CNI_VERSION="${CNI_VERSION:-v1.2.0}"
       cni_base_url="https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION"
       cni_filename="cni-plugins-linux-$arch-$CNI_VERSION.tgz"
 
@@ -163,7 +163,7 @@ spec:
       cd -
 
       {{- /* # cri-tools variables */}}
-      CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.22.0}"
+      CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.26.0}"
       cri_tools_base_url="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}"
       cri_tools_filename="crictl-${CRI_TOOLS_RELEASE}-linux-${arch}.tar.gz"
 
@@ -171,8 +171,9 @@ spec:
       curl -Lfo "$opt_bin/$cri_tools_filename" "$cri_tools_base_url/$cri_tools_filename"
 
       {{- /* download cri-tools checksum */}}
-      {{- /* the cri-tools checksum file has a filename prefix that breaks sha256sum so we need to drop it with sed */}}
-      cri_tools_sum=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256" | sed 's/\*\///')
+      {{- /* the cri-tools checksum file provides only the checksum without the file name, so we need to handle it specially */}}
+      cri_tools_sum_value=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256")
+      cri_tools_sum="$cri_tools_sum_value $cri_tools_filename"
       cd "$opt_bin"
 
       {{- /* verify cri-tools checksum */}}


### PR DESCRIPTION
**What this PR does / why we need it**:

* Update containerd to 1.6
* Update Docker to 20.10
* Update kubernetes-cni to 1.2.0
* Update cri-tools to 1.26.0

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
* Update containerd to 1.6
* Update Docker to 20.10
* Update kubernetes-cni to 1.2.0
* Update cri-tools to 1.26.0
```

**Documentation**:
```documentation
NONE
```