### PR TITLE
Drop configurations from /proc/sys/ for flatcar with cloud-init

### DIFF
--- a/deploy/osps/default/osp-flatcar-cloud-init.yaml
+++ b/deploy/osps/default/osp-flatcar-cloud-init.yaml
@@ -730,28 +730,6 @@ spec:
               [Install]
               WantedBy=multi-user.target
 
-      ## Flatcar specific configuration
-      - path: /proc/sys/kernel/panic_on_oops
-        permissions: 644
-        content:
-          inline:
-            data: |
-              1
-
-      - path: /proc/sys/kernel/panic
-        permissions: 644
-        content:
-          inline:
-            data: |
-              10
-
-      - path: /proc/sys/vm/overcommit_memory
-        permissions: 644
-        content:
-          inline:
-            data: |
-              1
-
       - path: /etc/ssh/sshd_config
         permissions: 600
         content:


### PR DESCRIPTION
**What this PR does / why we need it**:
Cores cloud-init cannot write files to the`/proc` path due to the immutability of the Flatcar OS. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
