### PR TITLE
Set ProvisioningUtility in the OperatingSystemConfig

### DIFF
--- a/pkg/controllers/osc/osc_controller.go
+++ b/pkg/controllers/osc/osc_controller.go
@@ -231,7 +231,7 @@ func (r *Reconciler) reconcileOperatingSystemConfigs(ctx context.Context, md *cl
 	}
 
 	if osp.Spec.ProvisioningUtility != "" && provisioner != osp.Spec.ProvisioningUtility {
-		return fmt.Errorf("Specified provisioning utility is not supported by the OperatingSystemProfile: %w", err)
+		return fmt.Errorf("Specified provisioning utility %q is not supported by the OperatingSystemProfile", osp.Spec.ProvisioningUtility)
 	}
 
 	if r.nodeRegistryCredentialsSecret != "" {
@@ -274,6 +274,12 @@ func (r *Reconciler) reconcileOperatingSystemConfigs(ctx context.Context, md *cl
 	// Add machine deployment revision to OSC
 	revision := md.Annotations[machinecontrollerutil.RevisionAnnotation]
 	osc.Annotations = addMachineDeploymentRevision(revision, osc.Annotations)
+	osc.Spec.ProvisioningUtility = osp.Spec.ProvisioningUtility
+
+	// Defaults to cloud-init although we should never hit this condition i.e ProvisioningUtility in OSP to be empty.
+	if osc.Spec.ProvisioningUtility == "" {
+		osc.Spec.ProvisioningUtility = osmv1alpha1.ProvisioningUtilityCloudInit
+	}
 
 	// Create resource in cluster
 	if err := r.Create(ctx, osc); err != nil {

--- a/pkg/controllers/osc/testdata/osc-flatcar-aws-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-flatcar-aws-containerd.yaml
@@ -681,3 +681,4 @@ spec:
       name: setup.service
     userSSHKeys:
     - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu3c
+  provisioningUtility: ignition

--- a/pkg/controllers/osc/testdata/osc-kubelet-configuration-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-kubelet-configuration-containerd.yaml
@@ -677,3 +677,4 @@ spec:
       permissions: 600
     userSSHKeys:
     - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu3c
+  provisioningUtility: cloud-init

--- a/pkg/controllers/osc/testdata/osc-rhel-8.x-azure-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-rhel-8.x-azure-containerd.yaml
@@ -716,3 +716,4 @@ spec:
         username: ""
     userSSHKeys:
     - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu3c
+  provisioningUtility: cloud-init

--- a/pkg/controllers/osc/testdata/osc-rhel-8.x-cloud-init-modules.yaml
+++ b/pkg/controllers/osc/testdata/osc-rhel-8.x-cloud-init-modules.yaml
@@ -702,3 +702,4 @@ spec:
           type: rpm-md
     userSSHKeys:
     - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu3c
+  provisioningUtility: cloud-init

--- a/pkg/controllers/osc/testdata/osc-ubuntu-aws-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-aws-containerd.yaml
@@ -681,3 +681,4 @@ spec:
       permissions: 600
     userSSHKeys:
     - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu3c
+  provisioningUtility: cloud-init

--- a/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack-IPv6+IPv4.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack-IPv6+IPv4.yaml
@@ -689,3 +689,4 @@ spec:
       permissions: 600
     userSSHKeys:
     - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu3c
+  provisioningUtility: cloud-init

--- a/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack.yaml
@@ -688,3 +688,4 @@ spec:
       permissions: 600
     userSSHKeys:
     - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDdOIhYmzCK5DSVLu3c
+  provisioningUtility: cloud-init

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -64,7 +64,7 @@ func (d *DefaultCloudConfigGenerator) Generate(config *osmv1alpha1.OSCConfig, pr
 	}
 
 	if provisioningUtility != "" && provisioner != provisioningUtility {
-		return nil, fmt.Errorf("Specified provisioning utility is not supported by the OperatingSystemConfig: %w", err)
+		return nil, fmt.Errorf("Specified provisioning utility %q is not supported by the OperatingSystemConfig", provisioningUtility)
 	}
 
 	var files []*fileSpec


### PR DESCRIPTION
**What this PR does / why we need it**:
We set `ProvisioningUtility` in the OSP and try to match it with the MachineDeployment. Although this value was not propagated to the OperatingSystemConfig.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
