### PR TITLE
Flatcar cloud-init OSP: fix setting up kernel for kubelet

### DIFF
--- a/deploy/osps/default/osp-flatcar-cloud-init.yaml
+++ b/deploy/osps/default/osp-flatcar-cloud-init.yaml
@@ -21,7 +21,7 @@ spec:
   osName: flatcar
   ## Flatcar Stable (09/11/2021)
   osVersion: "2983.2.0"
-  version: "v1.0.1"
+  version: "v1.0.2"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "anexia"
@@ -575,14 +575,22 @@ spec:
               [Service]
               Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
+      - path: /opt/bin/setup_kernel_for_kubelet.sh
+        permissions: 755
+        content:
+          inline:
+            data: |
+              #!/bin/sh
+              echo 1  > /proc/sys/kernel/panic_on_oops
+              echo 10 > /proc/sys/kernel/panic
+              echo 1  > /proc/sys/vm/overcommit_memory
+
       - path: /etc/systemd/system/kubelet.service.d/flatcar-system-config.conf
         content:
           inline:
             data: |
               [Service]
-              ExecStartPre=/bin/echo 1  > /proc/sys/kernel/panic_on_oops
-              ExecStartPre=/bin/echo 10 > /proc/sys/kernel/panic
-              ExecStartPre=/bin/echo 1  > /proc/sys/vm/overcommit_memory
+              ExecStartPre=/opt/bin/setup_kernel_for_kubelet.sh
 
       - path: /etc/kubernetes/cloud-config
         permissions: 600


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the kernel configuration needed for kubelet.

Was re-added as part of the kubelet unit in #272, but the output redirection is not interpreted by systemd, which instead just passes it as arguments to echo.

Also see https://github.com/kubermatic/machine-controller/pull/1582#issuecomment-1497156133 where I uncovered this.

**What type of PR is this?**

/kind bug

**Special notes for your reviewer**:

I'm pretty sure I tested that change before, no clue what went wrong .. leaving this PR here as a draft and gonna test it and only after that succeeds will remove the draft status.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
