### PR TITLE
Forbid users from using units with operating systems other than flatcar

### DIFF
--- a/pkg/admission/operatingsystemprofile/validation/validation.go
+++ b/pkg/admission/operatingsystemprofile/validation/validation.go
@@ -84,7 +84,7 @@ func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequ
 		}
 
 	case admissionv1.Delete:
-		// NOP we always allow create, delete operarions at the moment
+		// NOP we always allow delete operarions at the moment
 
 	default:
 		return admission.Errored(http.StatusBadRequest, fmt.Errorf("%s not supported on osp resources", req.Operation))


### PR DESCRIPTION
**What this PR does / why we need it**:
Units are only supported with flatcar and rest of the OS's rely on files to configure everything.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #282

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
