### PR TITLE
Bump default OSPs to v1.3.0

### DIFF
--- a/deploy/osps/default/osp-amzn2.yaml
+++ b/deploy/osps/default/osp-amzn2.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "amzn2"
   osVersion: "2.0"
-  version: "v1.2.0"
+  version: "v1.3.0"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-centos.yaml
+++ b/deploy/osps/default/osp-centos.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "centos"
   osVersion: "7.7"
-  version: "v1.2.0"
+  version: "v1.3.0"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "alibaba"

--- a/deploy/osps/default/osp-flatcar-cloud-init.yaml
+++ b/deploy/osps/default/osp-flatcar-cloud-init.yaml
@@ -21,7 +21,7 @@ spec:
   osName: flatcar
   ## Flatcar Stable (09/11/2021)
   osVersion: "2983.2.0"
-  version: "v1.0.2"
+  version: "v1.3.0"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "anexia"
@@ -762,21 +762,21 @@ spec:
               {{- end }}
 
     units:
-    - name: setup.service
-      enable: true
-      content: |
-        [Install]
-        WantedBy=multi-user.target
+      - name: setup.service
+        enable: true
+        content: |
+          [Install]
+          WantedBy=multi-user.target
 
-        [Unit]
-        Requires=network-online.target
-        After=network-online.target
+          [Unit]
+          Requires=network-online.target
+          After=network-online.target
 
-        [Service]
-        Type=oneshot
-        RemainAfterExit=true
-        EnvironmentFile=-/etc/environment
-        ExecStart=/opt/bin/supervise.sh /opt/bin/setup
+          [Service]
+          Type=oneshot
+          RemainAfterExit=true
+          EnvironmentFile=-/etc/environment
+          ExecStart=/opt/bin/supervise.sh /opt/bin/setup
 
   # We can't use provisioning configuration here since Anexia doesn't support second `cloud-init` init. Hence all the
   # required configurations have been moved to the bootstrap phase instead.

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -21,7 +21,7 @@ spec:
   osName: flatcar
   ## Flatcar Stable (09/11/2021)
   osVersion: "2983.2.0"
-  version: "v1.2.0"
+  version: "v1.3.0"
   provisioningUtility: "ignition"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-rhel.yaml
+++ b/deploy/osps/default/osp-rhel.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "rhel"
   osVersion: "8.5"
-  version: "v1.2.0"
+  version: "v1.3.0"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-rockylinux.yaml
+++ b/deploy/osps/default/osp-rockylinux.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "rockylinux"
   osVersion: "8.6"
-  version: "v1.2.0"
+  version: "v1.3.0"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "ubuntu"
   osVersion: "20.04"
-  version: "v1.2.0"
+  version: "v1.3.0"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "alibaba"

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,6 @@
+# Release Procedure
+
+List of steps to follow for creating a new release for this project:
+
+- [ ] Testing to ensure that the release is working as expected.
+- [ ] Version bump the default OperatingSystemProfiles in [here](../deploy/osps/default/).


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump default OSPs to v1.3.0 in anticipation for the next OSM release.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
