### PR TITLE
Remove docker support

### DIFF
--- a/deploy/crd/operatingsystemmanager.k8c.io_operatingsystemprofiles.yaml
+++ b/deploy/crd/operatingsystemmanager.k8c.io_operatingsystemprofiles.yaml
@@ -123,7 +123,8 @@ spec:
                     type: object
                   supportedContainerRuntimes:
                     description: SupportedContainerRuntimes represents the container
-                      runtimes supported by the given OS
+                      runtimes supported by the given OS. Docker has been deprecated
+                      and is no-op.
                     items:
                       description: ContainerRuntimeSpec aggregates information about
                         a specific container runtime
@@ -333,7 +334,8 @@ spec:
                     type: object
                   supportedContainerRuntimes:
                     description: SupportedContainerRuntimes represents the container
-                      runtimes supported by the given OS
+                      runtimes supported by the given OS. Docker has been deprecated
+                      and is no-op.
                     items:
                       description: ContainerRuntimeSpec aggregates information about
                         a specific container runtime

--- a/hack/kkp/operatingsystemmanager.k8c.io_customoperatingsystemprofiles.yaml
+++ b/hack/kkp/operatingsystemmanager.k8c.io_customoperatingsystemprofiles.yaml
@@ -114,7 +114,7 @@ spec:
                           type: object
                       type: object
                     supportedContainerRuntimes:
-                      description: SupportedContainerRuntimes represents the container runtimes supported by the given OS
+                      description: SupportedContainerRuntimes represents the container runtimes supported by the given OS. Docker has been deprecated and is no-op.
                       items:
                         description: ContainerRuntimeSpec aggregates information about a specific container runtime
                         properties:
@@ -291,7 +291,7 @@ spec:
                           type: object
                       type: object
                     supportedContainerRuntimes:
-                      description: SupportedContainerRuntimes represents the container runtimes supported by the given OS
+                      description: SupportedContainerRuntimes represents the container runtimes supported by the given OS. Docker has been deprecated and is no-op.
                       items:
                         description: ContainerRuntimeSpec aggregates information about a specific container runtime
                         properties:
@@ -421,6 +421,7 @@ spec:
                           - baremetal
                           - external
                           - vmware-cloud-director
+                          - opennebula
                         type: string
                       spec:
                         description: Spec represents the os/image reference in the supported cloud provider

--- a/pkg/crd/osm/v1alpha1/operatingsystemprofile_types.go
+++ b/pkg/crd/osm/v1alpha1/operatingsystemprofile_types.go
@@ -62,7 +62,8 @@ type OperatingSystemProfileSpec struct {
 }
 
 type OSPConfig struct {
-	// SupportedContainerRuntimes represents the container runtimes supported by the given OS
+	// SupportedContainerRuntimes represents the container runtimes supported by the given OS.
+	// Docker has been deprecated and is no-op.
 	SupportedContainerRuntimes []ContainerRuntimeSpec `json:"supportedContainerRuntimes,omitempty"`
 	// Templates to be included in units and files
 	Templates map[string]string `json:"templates,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the remnants of docker container runtime. In general, since we don't support Kubernetes v1.24 anymore in the main branch, docker is not usable anyways.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support for container runtime docker has been removed
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
