### PR TITLE
Propagate datastore cluster for vSphere to cloud-config

### DIFF
--- a/pkg/cloudprovider/vsphere/provider.go
+++ b/pkg/cloudprovider/vsphere/provider.go
@@ -97,6 +97,16 @@ func getConfig(pconfig providerconfigtypes.Config) (*types.CloudConfig, error) {
 		return nil, err
 	}
 
+	datastoreCluster, err := config.GetConfigVarResolver().GetConfigVarStringValue(rawConfig.DatastoreCluster)
+	if err != nil {
+		return nil, err
+	}
+
+	defaultDatastore := datastore
+	if len(defaultDatastore) == 0 {
+		defaultDatastore = datastoreCluster
+	}
+
 	workingDir := folder
 	// Default to basedir
 	if workingDir == "" {
@@ -111,7 +121,7 @@ func getConfig(pconfig providerconfigtypes.Config) (*types.CloudConfig, error) {
 		Workspace: types.WorkspaceOpts{
 			Datacenter:       datacenter,
 			VCenterIP:        vsphereURL.Hostname(),
-			DefaultDatastore: datastore,
+			DefaultDatastore: defaultDatastore,
 			Folder:           workingDir,
 		},
 		VirtualCenter: map[string]*types.VirtualCenterConfig{

--- a/pkg/cloudprovider/vsphere/types/types.go
+++ b/pkg/cloudprovider/vsphere/types/types.go
@@ -29,7 +29,8 @@ type RawConfig struct {
 	Folder         types.ConfigVarString `json:"folder"`
 
 	// Either Datastore or DatastoreCluster have to be provided.
-	Datastore types.ConfigVarString `json:"datastore"`
+	DatastoreCluster types.ConfigVarString `json:"datastoreCluster"`
+	Datastore        types.ConfigVarString `json:"datastore"`
 
 	AllowInsecure types.ConfigVarBool `json:"allowInsecure"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In case user has specified `DatastoreCluster` for a machine deployment on vSphere, we should use that as the `datastore` in cloud-config so that the disks attached to the VM are placed accordingly.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
vSphere: Fix a bug where datastore cluster value was not being propagated to the cloud-config
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
