### PR TITLE
Remove k8s 1.25 from supported versions

### DIFF
--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -7,7 +7,6 @@ Currently supported K8S versions are:
 - 1.28
 - 1.27
 - 1.26
-- 1.25
 
 ## Operating System
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubernetes v1.25 will be EOL on 27 Oct 2023

https://kubernetes.io/releases/#release-v1-25

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove support for Kubernetes v1.25 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
