### PR TITLE
[release/v1.2] Update default OSP versions to v1.2.3

### DIFF
--- a/deploy/osps/default/osp-amzn2.yaml
+++ b/deploy/osps/default/osp-amzn2.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "amzn2"
   osVersion: "2.0"
-  version: "v1.2.1"
+  version: "v1.2.3"
   supportedCloudProviders:
     - name: "aws"
 

--- a/deploy/osps/default/osp-centos.yaml
+++ b/deploy/osps/default/osp-centos.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "centos"
   osVersion: "7.7"
-  version: "v1.2.1"
+  version: "v1.2.3"
   supportedCloudProviders:
     - name: "alibaba"
     - name: "aws"

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -21,7 +21,7 @@ spec:
   osName: flatcar
   ## Flatcar Stable (09/11/2021)
   osVersion: "2983.2.0"
-  version: "v1.2.0"
+  version: "v1.2.3"
   supportedCloudProviders:
     - name: "aws"
     - name: "azure"

--- a/deploy/osps/default/osp-rhel.yaml
+++ b/deploy/osps/default/osp-rhel.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "rhel"
   osVersion: "8.5"
-  version: "v1.2.1"
+  version: "v1.2.3"
   supportedCloudProviders:
     - name: "aws"
     - name: "azure"

--- a/deploy/osps/default/osp-rockylinux.yaml
+++ b/deploy/osps/default/osp-rockylinux.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "rockylinux"
   osVersion: "8.6"
-  version: "v1.2.1"
+  version: "v1.2.3"
   supportedCloudProviders:
     - name: "aws"
     - name: "azure"

--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "ubuntu"
   osVersion: "20.04"
-  version: "v1.2.1"
+  version: "v1.2.3"
   supportedCloudProviders:
     - name: "alibaba"
     - name: "aws"


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the OSP versions in `release/v1.2` to match the upcoming OSM release to incorporate #314.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
