### PR TITLE
Drop in-tree support for OpenStack

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -60,8 +60,7 @@ func GetCloudConfig(pconfig providerconfigtypes.Config, kubeletVersion string) (
 
 func KubeletCloudProviderConfig(cloudProvider providerconfigtypes.CloudProvider, external bool) (inTreeCCM bool, outOfTree bool, err error) {
 	switch osmv1alpha1.CloudProvider(cloudProvider) {
-	case osmv1alpha1.CloudProviderAWS, osmv1alpha1.CloudProviderAzure,
-		osmv1alpha1.CloudProviderOpenstack, osmv1alpha1.CloudProviderVsphere:
+	case osmv1alpha1.CloudProviderAWS, osmv1alpha1.CloudProviderAzure, osmv1alpha1.CloudProviderVsphere:
 		if external {
 			return false, true, nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Starting from Kubernetes v1.26, external CCM is required for OpenStack as in-tree support has been removed.

- https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md#:~:text=%40liggitt)-,The%20in%2Dtree%20cloud%20provider%20for%20OpenStack,-(and%20the%20cinder
- https://github.com/kubernetes/kubernetes/pull/67782

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Drop in-tree support for OpenStack; Starting from Kubernetes v1.26, external CCM is required for OpenStack as in-tree support has been removed.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
