### PR TITLE
Drop centos support for Hetzner

### DIFF
--- a/deploy/osps/default/osp-centos.yaml
+++ b/deploy/osps/default/osp-centos.yaml
@@ -28,7 +28,6 @@ spec:
     - name: "azure"
     - name: "digitalocean"
     - name: "equinixmetal"
-    - name: "hetzner"
     - name: "kubevirt"
     - name: "nutanix"
     - name: "openstack"

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -17,7 +17,7 @@ Currently supported K8S versions are:
 | Digitalocean  | ✓ | ✓ | x | x | x | ✓ |
 | Equinix Metal  | ✓ | ✓ | ✓ | x | x | ✓ |
 | Google Cloud Platform | ✓ | x | x | x | x | x |
-| Hetzner | ✓ | ✓ | x | x | x | ✓ |
+| Hetzner | ✓ | x | x | x | x | ✓ |
 | KubeVirt | ✓ | ✓ | ✓ | x | ✓ | ✓ |
 | Nutanix | ✓ | ✓ | x | x | x | x |
 | Openstack | ✓ | ✓ | ✓ | x | ✓ | ✓ |


### PR DESCRIPTION
**What this PR does / why we need it**:
Hetzner has deprecated their CentOS 7 image. CentOS 7 was/is the only release we ever supported and so this now means that there is no CentOS support at all anymore on Hetzner.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Removed support for centos with Hetzner
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
