### PR TITLE
Added support for Flatcar on VMware Cloud Director

### DIFF
--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -30,7 +30,7 @@ spec:
     - name: "kubevirt"
     - name: "openstack"
     - name: "vsphere"
-
+    - name: "vmware-cloud-director"
   bootstrapConfig:
     templates:
       configureProxyScript: |-
@@ -51,7 +51,56 @@ spec:
         {{- end }}
 
         source /etc/environment
-
+      configureVCloudNetwork: |-
+        function query_ovf () {
+          local QUERY=$1
+          echo $(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ovfEnv" | grep "${QUERY}" | sed -e 's/.*oe:value="//g' | sed 's/"\/>//g')
+        }
+        
+        mask2cdr () {
+          local mask=$1
+        
+          # In RFC 4632 netmasks there's no "255." after a non-255 byte in the mask
+          local left_stripped_mask=${mask##*255.}
+          local len_mask=${#mask}
+          local len_left_stripped_mask=${#left_stripped_mask}
+        
+          local conversion_table=0^^^128^192^224^240^248^252^254^
+          local number_of_bits_stripped=$(( ($len_mask - $len_left_stripped_mask)*2 ))
+          local signifacant_octet=${left_stripped_mask%%.*}
+        
+          local right_stripped_conversion_table=${conversion_table%%$signifacant_octet*}
+          local len_right_stripped_conversion_table=${#right_stripped_conversion_table}
+          local number_of_bits_from_conversion_table=$((len_right_stripped_conversion_table/4))
+          echo $(( $number_of_bits_stripped + $number_of_bits_from_conversion_table ))
+        }
+        
+        HOSTNAME=$(query_ovf "vCloud_computerName")
+        PRIMARY_NIC=$(query_ovf "vCloud_primaryNic")
+        IP_MODE=$(query_ovf "vCloud_bootproto_${PRIMARY_NIC}")
+        
+        if [ "$IP_MODE" = "static" ]; then
+        IP=$(query_ovf "vCloud_ip_${PRIMARY_NIC}")
+        GATEWAY=$(query_ovf "vCloud_gateway_${PRIMARY_NIC}")
+        DNS1=$(query_ovf "vCloud_dns1_${PRIMARY_NIC}")
+        DNS2=$(query_ovf "vCloud_dns2_${PRIMARY_NIC}")
+        NETMASK=$(query_ovf "vCloud_netmask_${PRIMARY_NIC}")
+        CIDR=$(mask2cdr "$NETMASK")
+        cat <<EOF > /etc/systemd/network/00-ens192.network
+        [Match]
+        Name=ens192
+        
+        [Network]
+        Address=$IP/$CIDR
+        Gateway=$GATEWAY
+        DNS=$DNS1 $DNS2
+        EOF
+        
+        fi
+        
+        hostnamectl set-hostname $HOSTNAME
+        
+        systemctl restart systemd-networkd
     units:
       - name: bootstrap.service
         enable: true
@@ -89,6 +138,12 @@ spec:
             data: |
               #!/bin/bash
               set -xeuo pipefail
+
+              {{- /* Need to configure networking manually when using VMWare Cloud director with static ip */}}
+              {{- if eq .CloudProviderName "vmware-cloud-director" }}
+              {{- template "configureVCloudNetwork" }}
+              {{- end }}
+
 
               {{- /* Configure proxy as the first step to ensure that all the phases of provisioning respect the proxy environment. */}}
               {{- template "configureProxyScript" }}

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -56,28 +56,28 @@ spec:
           local QUERY=$1
           echo $(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ovfEnv" | grep "${QUERY}" | sed -e 's/.*oe:value="//g' | sed 's/"\/>//g')
         }
-        
+
         mask2cdr () {
           local mask=$1
-        
+
           # In RFC 4632 netmasks there's no "255." after a non-255 byte in the mask
           local left_stripped_mask=${mask##*255.}
           local len_mask=${#mask}
           local len_left_stripped_mask=${#left_stripped_mask}
-        
+
           local conversion_table=0^^^128^192^224^240^248^252^254^
           local number_of_bits_stripped=$(( ($len_mask - $len_left_stripped_mask)*2 ))
           local signifacant_octet=${left_stripped_mask%%.*}
-        
+
           local right_stripped_conversion_table=${conversion_table%%$signifacant_octet*}
           local len_right_stripped_conversion_table=${#right_stripped_conversion_table}
           local number_of_bits_from_conversion_table=$((len_right_stripped_conversion_table/4))
           echo $(( $number_of_bits_stripped + $number_of_bits_from_conversion_table ))
         }
-        
+
         PRIMARY_NIC=$(query_ovf "vCloud_primaryNic")
         IP_MODE=$(query_ovf "vCloud_bootproto_${PRIMARY_NIC}")
-        
+
         if [ "$IP_MODE" = "static" ]; then
         IP=$(query_ovf "vCloud_ip_${PRIMARY_NIC}")
         GATEWAY=$(query_ovf "vCloud_gateway_${PRIMARY_NIC}")
@@ -88,13 +88,13 @@ spec:
         cat <<EOF > /etc/systemd/network/00-ens192.network
         [Match]
         Name=ens192
-        
+
         [Network]
         Address=$IP/$CIDR
         Gateway=$GATEWAY
         DNS=$DNS1 $DNS2
         EOF
-        
+
         systemctl restart systemd-networkd
 
         fi

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -51,7 +51,7 @@ spec:
         {{- end }}
 
         source /etc/environment
-      configureVCloudNetwork: |-
+      configureVCloudNetworkStatic: |-
         function query_ovf () {
           local QUERY=$1
           echo $(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ovfEnv" | grep "${QUERY}" | sed -e 's/.*oe:value="//g' | sed 's/"\/>//g')
@@ -75,7 +75,6 @@ spec:
           echo $(( $number_of_bits_stripped + $number_of_bits_from_conversion_table ))
         }
         
-        HOSTNAME=$(query_ovf "vCloud_computerName")
         PRIMARY_NIC=$(query_ovf "vCloud_primaryNic")
         IP_MODE=$(query_ovf "vCloud_bootproto_${PRIMARY_NIC}")
         
@@ -96,11 +95,10 @@ spec:
         DNS=$DNS1 $DNS2
         EOF
         
-        fi
-        
-        hostnamectl set-hostname $HOSTNAME
-        
         systemctl restart systemd-networkd
+
+        fi
+
     units:
       - name: bootstrap.service
         enable: true
@@ -141,7 +139,7 @@ spec:
 
               {{- /* Need to configure networking manually when using VMWare Cloud director with static ip */}}
               {{- if eq .CloudProviderName "vmware-cloud-director" }}
-              {{- template "configureVCloudNetwork" }}
+              {{- template "configureVCloudNetworkStatic" }}
               {{- end }}
 
 

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -21,5 +21,5 @@ Currently supported K8S versions are:
 | KubeVirt | ✓ | ✓ | ✓ | x | ✓ | ✓ |
 | Nutanix | ✓ | ✓ | x | x | x | x |
 | Openstack | ✓ | ✓ | ✓ | x | ✓ | ✓ |
-| VMware Cloud Director | ✓ | x | x | x | x | x |
+| VMware Cloud Director | ✓ | x | ✓ | x | x | x |
 | VSphere | ✓ | ✓ | ✓ | x | ✓ | ✓ |


### PR DESCRIPTION
**What this PR does / why we need it**:
Added and tested flatcar on VMware Cloud Director. There is an extra setup step needed to support static ips. The extra step is executed bootstrap only for VMware Cloud Director and parses the ip information from the vmtoolsd and generates a systemd network config

**Which issue(s) this PR fixes**:
This PR addresses the osm part of https://github.com/kubermatic/kubermatic/issues/12576

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Added support for flatcar on VMware Cloud Director
```

**Documentation**:
```documentation
NONE
```