### PR TITLE
Flatcar Support for GCE

### DIFF
--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -27,6 +27,7 @@ spec:
     - name: "aws"
     - name: "azure"
     - name: "equinixmetal"
+    - name: "gce"
     - name: "kubevirt"
     - name: "openstack"
     - name: "vsphere"

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -16,7 +16,7 @@ Currently supported K8S versions are:
 | Azure | ✓ | ✓ | ✓ | x | ✓ | ✓ |
 | Digitalocean  | ✓ | ✓ | x | x | x | ✓ |
 | Equinix Metal  | ✓ | ✓ | ✓ | x | x | ✓ |
-| Google Cloud Platform | ✓ | x | x | x | x | x |
+| Google Cloud Platform | ✓ | x | ✓ | x | x | x |
 | Hetzner | ✓ | x | x | x | x | ✓ |
 | KubeVirt | ✓ | ✓ | ✓ | x | ✓ | ✓ |
 | Nutanix | ✓ | ✓ | x | x | x | x |


### PR DESCRIPTION
**What this PR does / why we need it**:
This "whitelists" flatcar for GCE cloud provider. We don't need any changes other than just adding GCE as a supported cloud provider in the default flatcar OSP.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref https://github.com/kubermatic/kubermatic/issues/12728

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Flatcar is now supported on GCE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
