### PR TITLE
Add SIG Cluster Management as code owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,9 +2,12 @@
 
 approvers:
   - sig-osm
+  - sig-cluster-management
 
 reviewers:
   - sig-osm
+  - sig-cluster-management
 
 labels:
   - sig/osm
+  - sig/cluster-management

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,3 +5,11 @@ aliases:
   sig-osm:
     - ahmedwaleedmalik
     - moadqassem
+  sig-cluster-management:
+    - ahmedwaleedmalik
+    - embik
+    - kron4eg
+    - moadqassem
+    - moelsayed
+    - xmudrii
+    - xrstf


### PR DESCRIPTION
**What this PR does / why we need it**:
I would like to suggest adding SIG Cluster Management to the code owners for OSM, so that @ahmedwaleedmalik doesn't have to be the sole reviewer for changes - Unless he wishes to. This is entirely optional and can be closed if not in the interest of SIG OSM.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
