### PR TITLE
[release/v1.3] Update to Go 1.20.12

### DIFF
--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -26,7 +26,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.20-14
           command:
             - /bin/bash
             - -c
@@ -53,7 +53,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.20-14
           command:
             - "./hack/ci/upload-gocache.sh"
           resources:

--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -26,7 +26,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.20-13
           command:
             - /bin/bash
             - -c
@@ -53,7 +53,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.20-13
           command:
             - "./hack/ci/upload-gocache.sh"
           resources:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -79,7 +79,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.20-14
           command:
             - ./hack/verify-licenses.sh
           resources:
@@ -182,7 +182,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.20-14
           command:
             - "./hack/ci/run-e2e-tests.sh"
           resources:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -36,7 +36,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.20.5
+        - image: golang:1.20.12
           command:
             - make
           args:
@@ -58,7 +58,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-13
           command:
             - make
           args:
@@ -79,7 +79,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.20-13
           command:
             - ./hack/verify-licenses.sh
           resources:
@@ -161,7 +161,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.20.5
+        - image: golang:1.20.12
           command:
             - make
           args:
@@ -182,7 +182,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.20-13
           command:
             - "./hack/ci/run-e2e-tests.sh"
           resources:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -58,7 +58,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-13
+        - image: quay.io/kubermatic/build:go-1.20-node-18-14
           command:
             - make
           args:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GO_VERSION=1.20.5
+ARG GO_VERSION=1.20.12
 FROM golang:${GO_VERSION} AS builder
 WORKDIR /go/src/k8c.io/operating-system-manager
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ export GO111MODULE=on
 export GOFLAGS?=-mod=readonly -trimpath
 export GIT_TAG ?= $(shell git tag --points-at HEAD)
 
-GO_VERSION = 1.20.5
+GO_VERSION = 1.20.12
 
 CMD = $(notdir $(wildcard ./cmd/*))
 BUILD_DEST ?= _build

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.20.5 containerize ./hack/update-codegen.sh
+CONTAINERIZE_IMAGE=golang:1.20.12 containerize ./hack/update-codegen.sh
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 
 sed="sed"

--- a/hack/update-crds-openapi.sh
+++ b/hack/update-crds-openapi.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.20.5 containerize ./hack/update-crds-openapi.sh
+CONTAINERIZE_IMAGE=golang:1.20.12 containerize ./hack/update-crds-openapi.sh
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 
 echodate "Creating vendor directory"

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-kind-0.20-13 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-kind-0.20-14 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-kind-0.20-13 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps Prow jobs for the `release/v1.3` branch to use a build image that includes Go 1.20.12.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Towards https://github.com/kubermatic/release/issues/22

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
OSM is now built using Go 1.20.12
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
