### PR TITLE
Remove sig-osm

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,10 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - sig-osm
   - sig-cluster-management
 
 reviewers:
-  - sig-osm
   - sig-cluster-management
 
 labels:
-  - sig/osm
   - sig/cluster-management

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,6 +11,3 @@ aliases:
     - moelsayed
     - xmudrii
     - xrstf
-  sig-osm:
-    - ahmedwaleedmalik
-    - moadqassem


### PR DESCRIPTION
**What this PR does / why we need it**:
With https://github.com/kubermatic/operating-system-manager/pull/336, sig-cluster-management took over the ownership for OSM which makes sig-osm redundant.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
