### PR TITLE
use external CCM for GCE

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -60,15 +60,11 @@ func GetCloudConfig(pconfig providerconfigtypes.Config, kubeletVersion string) (
 
 func KubeletCloudProviderConfig(cloudProvider providerconfigtypes.CloudProvider, external bool) (inTreeCCM bool, outOfTree bool, err error) {
 	switch osmv1alpha1.CloudProvider(cloudProvider) {
-	case osmv1alpha1.CloudProviderAWS, osmv1alpha1.CloudProviderAzure, osmv1alpha1.CloudProviderVsphere:
-		if external {
-			return false, true, nil
-		}
-
-		return true, false, nil
-
-	case osmv1alpha1.CloudProviderGoogle:
-		return true, false, nil
+	case osmv1alpha1.CloudProviderAWS,
+		osmv1alpha1.CloudProviderAzure,
+		osmv1alpha1.CloudProviderGoogle,
+		osmv1alpha1.CloudProviderVsphere:
+		return !external, external, nil
 
 	default:
 		return false, external, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
KKP now installs the external CCM for GCP, so for 1.29 tests we need to enable the appropriate flags for the kubelet.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Set `--cloud-provider=external` for GCE when external CCM is installed.
```

**Documentation**:
```documentation
NONE
```
