### PR TITLE
Drop capability to disable disablecloudproviders feature gate

### DIFF
--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -117,9 +117,9 @@ presubmits:
       containers:
         - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.21-2
           command:
-            - "sh"
-            - "-c"
-            - "yamllint -c .yamllint.conf ."
+            - make
+          args:
+            - yamllint
           resources:
             requests:
               cpu: 200m

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -115,7 +115,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/yamllint:0.1
+        - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.21-2
           command:
             - "sh"
             - "-c"

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ lint:
 	@golangci-lint --version
 	golangci-lint run -v ./pkg/...
 
+yamllint:
+	yamllint -c .yamllint.conf .
+
 .PHONY: vendor
 vendor: buildenv
 	go mod vendor

--- a/deploy/osps/default/osp-amzn2.yaml
+++ b/deploy/osps/default/osp-amzn2.yaml
@@ -524,12 +524,10 @@ spec:
                 --cert-dir=/etc/kubernetes/pki \
                 {{- if .ExternalCloudProvider }}
                 --cloud-provider=external \
-                {{- else if .InTreeCCMAvailable }}
                 {{- /* In-tree cloud providers have been disabled starting from k8s 1.29. For more information: https://github.com/kubernetes/kubernetes/pull/117503 */}}
-                {{- if or (semverCompare "<1.29" .KubeVersion) (.DisableCloudProvidersFeatureGateDisabled) }}
+                {{- else if and (.InTreeCCMAvailable) (semverCompare "<1.29" .KubeVersion) }}
                 --cloud-provider={{- .CloudProviderName }} \
                 --cloud-config=/etc/kubernetes/cloud-config \
-                {{- end }}
                 {{- end }}
                 {{- if ne .CloudProviderName "aws" }}
                 --hostname-override=${KUBELET_HOSTNAME} \

--- a/deploy/osps/default/osp-centos.yaml
+++ b/deploy/osps/default/osp-centos.yaml
@@ -563,12 +563,10 @@ spec:
                 --cert-dir=/etc/kubernetes/pki \
                 {{- if .ExternalCloudProvider }}
                 --cloud-provider=external \
-                {{- else if .InTreeCCMAvailable }}
                 {{- /* In-tree cloud providers have been disabled starting from k8s 1.29. For more information: https://github.com/kubernetes/kubernetes/pull/117503 */}}
-                {{- if or (semverCompare "<1.29" .KubeVersion) (.DisableCloudProvidersFeatureGateDisabled) }}
+                {{- else if and (.InTreeCCMAvailable) (semverCompare "<1.29" .KubeVersion) }}
                 --cloud-provider={{- .CloudProviderName }} \
                 --cloud-config=/etc/kubernetes/cloud-config \
-                {{- end }}
                 {{- end }}
                 {{- if ne .CloudProviderName "aws" }}
                 --hostname-override=${KUBELET_HOSTNAME} \

--- a/deploy/osps/default/osp-flatcar-cloud-init.yaml
+++ b/deploy/osps/default/osp-flatcar-cloud-init.yaml
@@ -543,12 +543,10 @@ spec:
                 --cert-dir=/etc/kubernetes/pki \
                 {{- if .ExternalCloudProvider }}
                 --cloud-provider=external \
-                {{- else if .InTreeCCMAvailable }}
                 {{- /* In-tree cloud providers have been disabled starting from k8s 1.29. For more information: https://github.com/kubernetes/kubernetes/pull/117503 */}}
-                {{- if or (semverCompare "<1.29" .KubeVersion) (.DisableCloudProvidersFeatureGateDisabled) }}
+                {{- else if and (.InTreeCCMAvailable) (semverCompare "<1.29" .KubeVersion) }}
                 --cloud-provider={{- .CloudProviderName }} \
                 --cloud-config=/etc/kubernetes/cloud-config \
-                {{- end }}
                 {{- end }}
                 {{- if ne .CloudProviderName "aws" }}
                 --hostname-override=${KUBELET_HOSTNAME} \

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -656,12 +656,10 @@ spec:
                 --cert-dir=/etc/kubernetes/pki \
                 {{- if .ExternalCloudProvider }}
                 --cloud-provider=external \
-                {{- else if .InTreeCCMAvailable }}
                 {{- /* In-tree cloud providers have been disabled starting from k8s 1.29. For more information: https://github.com/kubernetes/kubernetes/pull/117503 */}}
-                {{- if or (semverCompare "<1.29" .KubeVersion) (.DisableCloudProvidersFeatureGateDisabled) }}
+                {{- else if and (.InTreeCCMAvailable) (semverCompare "<1.29" .KubeVersion) }}
                 --cloud-provider={{- .CloudProviderName }} \
                 --cloud-config=/etc/kubernetes/cloud-config \
-                {{- end }}
                 {{- end }}
                 {{- if ne .CloudProviderName "aws" }}
                 --hostname-override=${KUBELET_HOSTNAME} \

--- a/deploy/osps/default/osp-rhel.yaml
+++ b/deploy/osps/default/osp-rhel.yaml
@@ -566,12 +566,10 @@ spec:
                 --cert-dir=/etc/kubernetes/pki \
                 {{- if .ExternalCloudProvider }}
                 --cloud-provider=external \
-                {{- else if .InTreeCCMAvailable }}
                 {{- /* In-tree cloud providers have been disabled starting from k8s 1.29. For more information: https://github.com/kubernetes/kubernetes/pull/117503 */}}
-                {{- if or (semverCompare "<1.29" .KubeVersion) (.DisableCloudProvidersFeatureGateDisabled) }}
+                {{- else if and (.InTreeCCMAvailable) (semverCompare "<1.29" .KubeVersion) }}
                 --cloud-provider={{- .CloudProviderName }} \
                 --cloud-config=/etc/kubernetes/cloud-config \
-                {{- end }}
                 {{- end }}
                 {{- if ne .CloudProviderName "aws" }}
                 --hostname-override=${KUBELET_HOSTNAME} \

--- a/deploy/osps/default/osp-rockylinux.yaml
+++ b/deploy/osps/default/osp-rockylinux.yaml
@@ -570,12 +570,10 @@ spec:
                 --cert-dir=/etc/kubernetes/pki \
                 {{- if .ExternalCloudProvider }}
                 --cloud-provider=external \
-                {{- else if .InTreeCCMAvailable }}
                 {{- /* In-tree cloud providers have been disabled starting from k8s 1.29. For more information: https://github.com/kubernetes/kubernetes/pull/117503 */}}
-                {{- if or (semverCompare "<1.29" .KubeVersion) (.DisableCloudProvidersFeatureGateDisabled) }}
+                {{- else if and (.InTreeCCMAvailable) (semverCompare "<1.29" .KubeVersion) }}
                 --cloud-provider={{- .CloudProviderName }} \
                 --cloud-config=/etc/kubernetes/cloud-config \
-                {{- end }}
                 {{- end }}
                 {{- if ne .CloudProviderName "aws" }}
                 --hostname-override=${KUBELET_HOSTNAME} \

--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -573,12 +573,10 @@ spec:
                 --cert-dir=/etc/kubernetes/pki \
                 {{- if .ExternalCloudProvider }}
                 --cloud-provider=external \
-                {{- else if .InTreeCCMAvailable }}
                 {{- /* In-tree cloud providers have been disabled starting from k8s 1.29. For more information: https://github.com/kubernetes/kubernetes/pull/117503 */}}
-                {{- if or (semverCompare "<1.29" .KubeVersion) (.DisableCloudProvidersFeatureGateDisabled) }}
+                {{- else if and (.InTreeCCMAvailable) (semverCompare "<1.29" .KubeVersion) }}
                 --cloud-provider={{- .CloudProviderName }} \
                 --cloud-config=/etc/kubernetes/cloud-config \
-                {{- end }}
                 {{- end }}
                 {{- if ne .CloudProviderName "aws" }}
                 --hostname-override=${KUBELET_HOSTNAME} \

--- a/pkg/controllers/osc/osc_reconciler_test.go
+++ b/pkg/controllers/osc/osc_reconciler_test.go
@@ -121,8 +121,6 @@ type testConfig struct {
 }
 
 func TestReconciler_Reconcile(t *testing.T) {
-	disableCloudProviderFeatureGate := map[string]bool{"DisableCloudProviders": false}
-
 	var testCases = []struct {
 		name                   string
 		kubeletVersion         string
@@ -154,25 +152,6 @@ func TestReconciler_Reconcile(t *testing.T) {
 				containerRuntime:      "containerd",
 				externalCloudProvider: true,
 				clusterDNSIPs:         []net.IP{net.IPv4(10, 0, 0, 0)},
-			},
-			cloudProvider:     "aws",
-			cloudProviderSpec: runtime.RawExtension{Raw: []byte(`{"availabilityZone": "eu-central-1b", "vpcId": "e-123f", "subnetID": "test-subnet"}`)},
-		},
-		{
-			name:                   "Ubuntu OS in AWS with DisableCloudProviders feature gate disabled",
-			ospFile:                defaultOSPPathPrefix + fmt.Sprintf("%s.yaml", ospUbuntu),
-			ospName:                ospUbuntu,
-			operatingSystem:        providerconfigtypes.OperatingSystemUbuntu,
-			oscFile:                "osc-ubuntu-aws.yaml",
-			mdName:                 "ubuntu-aws",
-			kubeletVersion:         "1.29.0",
-			provisioningSecretFile: "secret-ubuntu-aws-provisioning.yaml",
-			bootstrapSecretFile:    "secret-ubuntu-aws-bootstrap.yaml",
-			config: testConfig{
-				namespace:        "kube-system",
-				containerRuntime: "containerd",
-				clusterDNSIPs:    []net.IP{net.IPv4(10, 0, 0, 0)},
-				featureGates:     disableCloudProviderFeatureGate,
 			},
 			cloudProvider:     "aws",
 			cloudProviderSpec: runtime.RawExtension{Raw: []byte(`{"availabilityZone": "eu-central-1b", "vpcId": "e-123f", "subnetID": "test-subnet"}`)},

--- a/pkg/controllers/osc/resources/operating_system_config.go
+++ b/pkg/controllers/osc/resources/operating_system_config.go
@@ -58,8 +58,6 @@ const (
 	MachineDeploymentOSPNamespaceAnnotation = "k8c.io/operating-system-profile-namespace"
 
 	defaultFilePermissions = 644
-
-	disableCloudProviderFeatureGate = "DisableCloudProviders"
 )
 
 // GenerateOperatingSystemConfig return an OperatingSystemConfig generated against the input data
@@ -179,30 +177,24 @@ func GenerateOperatingSystemConfig(
 		cloudConfig = ""
 	}
 
-	disableCloudProvidersFeatureGateDisabled := false
-	if val, ok := kubeletFeatureGates[disableCloudProviderFeatureGate]; ok && !val {
-		disableCloudProvidersFeatureGateDisabled = true
-	}
-
 	data := filesData{
-		KubeVersion:                              kubeletVersionStr,
-		ClusterDNSIPs:                            clusterDNSIPs,
-		KubernetesCACert:                         caCert,
-		InTreeCCMAvailable:                       inTreeCCM,
-		CloudConfig:                              cloudConfig,
-		ContainerRuntime:                         containerRuntime,
-		CloudProviderName:                        osmv1alpha1.CloudProvider(providerConfig.CloudProvider),
-		ExternalCloudProvider:                    external,
-		PauseImage:                               pauseImage,
-		InitialTaints:                            initialTaints,
-		DisableCloudProvidersFeatureGateDisabled: disableCloudProvidersFeatureGateDisabled,
-		ContainerRuntimeConfig:                   crConfig,
-		ContainerRuntimeAuthConfig:               crAuthConfig,
-		KubeletFeatureGates:                      kubeletFeatureGates,
-		kubeletConfig:                            kubeletConfigs,
-		BootstrapKubeconfig:                      bootstrapKubeconfigString,
-		bootstrapConfig:                          bc,
-		NetworkIPFamily:                          string(networkIPFamily),
+		KubeVersion:                kubeletVersionStr,
+		ClusterDNSIPs:              clusterDNSIPs,
+		KubernetesCACert:           caCert,
+		InTreeCCMAvailable:         inTreeCCM,
+		CloudConfig:                cloudConfig,
+		ContainerRuntime:           containerRuntime,
+		CloudProviderName:          osmv1alpha1.CloudProvider(providerConfig.CloudProvider),
+		ExternalCloudProvider:      external,
+		PauseImage:                 pauseImage,
+		InitialTaints:              initialTaints,
+		ContainerRuntimeConfig:     crConfig,
+		ContainerRuntimeAuthConfig: crAuthConfig,
+		KubeletFeatureGates:        kubeletFeatureGates,
+		kubeletConfig:              kubeletConfigs,
+		BootstrapKubeconfig:        bootstrapKubeconfigString,
+		bootstrapConfig:            bc,
+		NetworkIPFamily:            string(networkIPFamily),
 	}
 
 	if len(nodeHTTPProxy) > 0 {
@@ -273,30 +265,29 @@ func GenerateOperatingSystemConfig(
 }
 
 type filesData struct {
-	KubeVersion                              string
-	KubeletConfiguration                     string
-	KubeletSystemdUnit                       string
-	BootstrapKubeconfig                      string
-	InTreeCCMAvailable                       bool
-	CNIVersion                               string
-	ClusterDNSIPs                            []net.IP
-	KubernetesCACert                         string
-	ServerAddress                            string
-	CloudConfig                              string
-	ContainerRuntime                         string
-	CloudProviderName                        osmv1alpha1.CloudProvider
-	NetworkConfig                            *providerconfigtypes.NetworkConfig
-	ExternalCloudProvider                    bool
-	PauseImage                               string
-	InitialTaints                            string
-	HTTPProxy                                *string
-	NoProxy                                  *string
-	ContainerRuntimeConfig                   string
-	ContainerRuntimeAuthConfig               string
-	KubeletFeatureGates                      map[string]bool
-	RHSubscription                           map[string]string
-	NetworkIPFamily                          string
-	DisableCloudProvidersFeatureGateDisabled bool
+	KubeVersion                string
+	KubeletConfiguration       string
+	KubeletSystemdUnit         string
+	BootstrapKubeconfig        string
+	InTreeCCMAvailable         bool
+	CNIVersion                 string
+	ClusterDNSIPs              []net.IP
+	KubernetesCACert           string
+	ServerAddress              string
+	CloudConfig                string
+	ContainerRuntime           string
+	CloudProviderName          osmv1alpha1.CloudProvider
+	NetworkConfig              *providerconfigtypes.NetworkConfig
+	ExternalCloudProvider      bool
+	PauseImage                 string
+	InitialTaints              string
+	HTTPProxy                  *string
+	NoProxy                    *string
+	ContainerRuntimeConfig     string
+	ContainerRuntimeAuthConfig string
+	KubeletFeatureGates        map[string]bool
+	RHSubscription             map[string]string
+	NetworkIPFamily            string
 
 	kubeletConfig
 	operatingSystemConfig

--- a/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
+++ b/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
@@ -573,12 +573,10 @@ spec:
                 --cert-dir=/etc/kubernetes/pki \
                 {{- if .ExternalCloudProvider }}
                 --cloud-provider=external \
-                {{- else if .InTreeCCMAvailable }}
                 {{- /* In-tree cloud providers have been disabled starting from k8s 1.29. For more information: https://github.com/kubernetes/kubernetes/pull/117503 */}}
-                {{- if or (semverCompare "<1.29" .KubeVersion) (.DisableCloudProvidersFeatureGateDisabled) }}
+                {{- else if and (.InTreeCCMAvailable) (semverCompare "<1.29" .KubeVersion) }}
                 --cloud-provider={{- .CloudProviderName }} \
                 --cloud-config=/etc/kubernetes/cloud-config \
-                {{- end }}
                 {{- end }}
                 {{- if ne .CloudProviderName "aws" }}
                 --hostname-override=${KUBELET_HOSTNAME} \


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduced in https://github.com/kubermatic/operating-system-manager/pull/344:

> We have added a special case/flag in order to determine if that feature gate has been disabled. This can be used to enable in-tree CCM functionality if required. We need this to run machine-controller e2e tests.

But this is not required.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
