### PR TITLE
[release/v1.3] Cloud-config is not required for external cloud providers

### DIFF
--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -115,11 +115,11 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/yamllint:0.1
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.20-14
           command:
-            - "sh"
-            - "-c"
-            - "yamllint -c .yamllint.conf ."
+            - make
+          args:
+            - yamllint
           resources:
             requests:
               cpu: 200m

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ lint:
 	@golangci-lint --version
 	golangci-lint run -v ./pkg/...
 
+yamllint:
+	yamllint -c .yamllint.conf .
+	
 .PHONY: vendor
 vendor: buildenv
 	go mod vendor

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -30,7 +30,11 @@ import (
 )
 
 // GetCloudConfig will return the cloud-config for machine
-func GetCloudConfig(pconfig providerconfigtypes.Config, kubeletVersion string) (string, error) {
+func GetCloudConfig(external bool, pconfig providerconfigtypes.Config, kubeletVersion string) (string, error) {
+	if external {
+		return "", nil
+	}
+
 	cloudProvider := osmv1alpha1.CloudProvider(pconfig.CloudProvider)
 
 	switch cloudProvider {

--- a/pkg/controllers/osc/resources/operating_system_config.go
+++ b/pkg/controllers/osc/resources/operating_system_config.go
@@ -102,16 +102,6 @@ func GenerateOperatingSystemConfig(
 
 	networkIPFamily := providerConfig.Network.GetIPFamily()
 
-	var cloudConfig string
-	if providerConfig.OverwriteCloudConfig != nil {
-		cloudConfig = *providerConfig.OverwriteCloudConfig
-	} else {
-		cloudConfig, err = cloudprovider.GetCloudConfig(providerConfig, md.Spec.Template.Spec.Versions.Kubelet)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch cloud-config: %w", err)
-		}
-	}
-
 	// Ensure that Kubelet version is prefixed by "v"
 	kubeletVersion, err := semver.NewVersion(md.Spec.Template.Spec.Versions.Kubelet)
 	if err != nil {
@@ -172,9 +162,14 @@ func GenerateOperatingSystemConfig(
 		return nil, err
 	}
 
-	if external &&
-		osmv1alpha1.CloudProvider(providerConfig.CloudProvider) == osmv1alpha1.CloudProviderVsphere {
-		cloudConfig = ""
+	var cloudConfig string
+	if providerConfig.OverwriteCloudConfig != nil {
+		cloudConfig = *providerConfig.OverwriteCloudConfig
+	} else {
+		cloudConfig, err = cloudprovider.GetCloudConfig(external, providerConfig, md.Spec.Template.Spec.Versions.Kubelet)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch cloud-config: %w", err)
+		}
 	}
 
 	data := filesData{

--- a/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Operating System Manager contributors.
+Copyright 2024 The Operating System Manager contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual cherry-pick for https://github.com/kubermatic/operating-system-manager/pull/353

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Cloud-config is no longer generated for external cloud providers.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
