### PR TITLE
Avoid second run of bootstrap script for flatcar with cloud-init

### DIFF
--- a/deploy/osps/default/osp-flatcar-cloud-init.yaml
+++ b/deploy/osps/default/osp-flatcar-cloud-init.yaml
@@ -201,6 +201,12 @@ spec:
               #!/bin/bash
               set -xeuo pipefail
 
+              # Check if bootstrap phase has already completed. This is required when we run `cloud-init init` again since it tries to re-run
+              # the bootstrap cloud-config as well, from the userdata.
+              if [ -f /etc/bootstrap-complete ]; then
+                exit 0
+              fi
+
               {{- /* Configure proxy as the first step to ensure that all the phases of provisioning respect the proxy environment. */}}
               {{- template "configureProxyScript" }}
 
@@ -262,6 +268,10 @@ spec:
 
               systemctl enable --now kubelet
               systemctl enable --now --no-block kubelet-healthcheck.service
+
+              # Bootstrap phase for the machine is complete.
+              touch /etc/bootstrap-complete
+
               systemctl disable setup.service
 
       - path: /opt/bin/health-monitor.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
Extending https://github.com/kubermatic/operating-system-manager/pull/273 and including the fix in flatcar-cloud-init OSP as well.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #364

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix an issue where cloud-init scripts re-ran on machine reboot
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
