### PR TITLE
Fix: Support vmtoolsd from $PATH

### DIFF
--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -55,7 +55,7 @@ spec:
       configureVCloudNetworkStatic: |-
         function query_ovf () {
           PATH=$PATH:/usr/share/oem/bin/
-          
+
           local QUERY=$1
           echo $(vmtoolsd --cmd "info-get guestinfo.ovfEnv" | grep "${QUERY}" | sed -e 's/.*oe:value="//g' | sed 's/"\/>//g')
         }

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -54,8 +54,13 @@ spec:
         source /etc/environment
       configureVCloudNetworkStatic: |-
         function query_ovf () {
+          VMTOOLSD_BINARY=vmtoolsd
+          
+          # Support for older images where vmtoolsd was not in PATH
+          type $VMTOOLSD_BINARY >/dev/null 2>&1 || { VMTOOLSD_BINARY=/usr/share/oem/bin/vmtoolsd; }
+          
           local QUERY=$1
-          echo $(/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.ovfEnv" | grep "${QUERY}" | sed -e 's/.*oe:value="//g' | sed 's/"\/>//g')
+          echo $($VMTOOLSD_BINARY --cmd "info-get guestinfo.ovfEnv" | grep "${QUERY}" | sed -e 's/.*oe:value="//g' | sed 's/"\/>//g')
         }
 
         mask2cdr () {

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -54,13 +54,10 @@ spec:
         source /etc/environment
       configureVCloudNetworkStatic: |-
         function query_ovf () {
-          VMTOOLSD_BINARY=vmtoolsd
-          
-          # Support for older images where vmtoolsd was not in PATH
-          type $VMTOOLSD_BINARY >/dev/null 2>&1 || { VMTOOLSD_BINARY=/usr/share/oem/bin/vmtoolsd; }
+          PATH=$PATH:/usr/share/oem/bin/
           
           local QUERY=$1
-          echo $($VMTOOLSD_BINARY --cmd "info-get guestinfo.ovfEnv" | grep "${QUERY}" | sed -e 's/.*oe:value="//g' | sed 's/"\/>//g')
+          echo $(vmtoolsd --cmd "info-get guestinfo.ovfEnv" | grep "${QUERY}" | sed -e 's/.*oe:value="//g' | sed 's/"\/>//g')
         }
 
         mask2cdr () {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adjusts the osp for flatcar on VMware cloud director. We now use the vmtoolsd binary from Path by default and only fallback to the old path if it does not exist. This is needed as newer flatcar releases have moved the binary to another location.


**What type of PR is this?**

/kind bug


**Special notes for your reviewer**:

Backwards compatibility is kept by falling back to the old path if binary was not found in $PATH 

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Fixes the network setup on vmware cloud director with flatcar, pool ips and the latest images 
```

**Documentation**:

```documentation
NONE
```
