### PR TITLE
Update golang to 1.22.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,13 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 run:
-  deadline: 20m
+  timeout: 20m
   issues-exit-code: 1
-  skip-dirs:
-    - hack
-    - vendor
-  skip-files:
-    - zz_generated.*.go
 
 linters:
   enable:
@@ -78,3 +73,8 @@ linters-settings:
 issues:
   exclude:
     - "cyclomatic complexity 32 of func `GenerateOperatingSystemConfig` is high"
+  exclude-dirs:
+    - hack
+    - vendor
+  exclude-files:
+    - zz_generated.*.go

--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -26,7 +26,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.22-5
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
           command:
             - /bin/bash
             - -c
@@ -53,7 +53,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.22-5
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
           command:
             - "./hack/ci/upload-gocache.sh"
           resources:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-5
+        - image: quay.io/kubermatic/build:go-1.22-node-20-3
           command:
             - make
           args:
@@ -36,7 +36,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-5
+        - image: quay.io/kubermatic/build:go-1.22-node-20-3
           command:
             - make
           args:
@@ -58,7 +58,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-5
+        - image: quay.io/kubermatic/build:go-1.22-node-20-3
           command:
             - make
           args:
@@ -79,7 +79,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-5
+        - image: quay.io/kubermatic/build:go-1.22-node-20-3
           command:
             - ./hack/verify-licenses.sh
           resources:
@@ -95,7 +95,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-5
+        - image: quay.io/kubermatic/build:go-1.22-node-20-3
           command:
             - make
           args:
@@ -115,7 +115,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-5
+        - image: quay.io/kubermatic/build:go-1.22-node-20-3
           command:
             - make
           args:
@@ -130,7 +130,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/operating-system-manager.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-5
+        - image: quay.io/kubermatic/build:go-1.22-node-20-3
           command:
             - shfmt
           args:
@@ -161,7 +161,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-5
+        - image: quay.io/kubermatic/build:go-1.22-node-20-3
           command:
             - make
           args:
@@ -182,7 +182,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.22-5
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
           command:
             - "./hack/ci/run-e2e-tests.sh"
           resources:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GO_VERSION=1.22.1
+ARG GO_VERSION=1.22.2
 FROM golang:${GO_VERSION} AS builder
 WORKDIR /go/src/k8c.io/operating-system-manager
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ export GO111MODULE=on
 export GOFLAGS?=-mod=readonly -trimpath
 export GIT_TAG ?= $(shell git tag --points-at HEAD)
 
-GO_VERSION = 1.22.1
+GO_VERSION = 1.22.2
 
 CMD = $(notdir $(wildcard ./cmd/*))
 BUILD_DEST ?= _build

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-18-5 containerize ./hack/update-codegen.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-20-3 containerize ./hack/update-codegen.sh
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 
 sed="sed"

--- a/hack/update-crds-openapi.sh
+++ b/hack/update-crds-openapi.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-18-5 containerize ./hack/update-crds-openapi.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-20-3 containerize ./hack/update-crds-openapi.sh
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 
 echodate "Creating vendor directory"

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-18-5 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-20-3 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
OSM is now built using Go 1.22.2
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
