### PR TITLE
Resolve DNS resolution issues for Hetzner on Ubuntu 24.04

### DIFF
--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: kube-system
 spec:
   osName: "ubuntu"
-  osVersion: "20.04"
+  osVersion: "24.04"
   version: "v1.5.0"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
@@ -106,6 +106,13 @@ spec:
               {{- /* Configure proxy as the first step to ensure that all the phases of provisioning respect the proxy environment. */}}
               {{- template "configureProxyScript" }}
               {{- template "configureHostCABundle" }}
+
+              {{- /* Starting with Ubuntu 24.04, there is an issue with DNS resolution that leaves machines without connectivity consistently. We even observed this issue on machines
+              where the netplan wasn't executed in the second cloud-init run. To fix this we are adding Cloudfare as fallback for DNS resolution */}}
+              {{- if eq .CloudProviderName "hetzner" }}
+              sed -i '/\[Resolve\]/a FallbackDNS=1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com 2606:4700:4700::1111#cloudflare-dns.com 2606:4700:4700::1001#cloudflare-dns.com' /etc/systemd/resolved.conf
+              systemctl restart systemd-resolved
+              {{- end }}
 
               export DEBIAN_FRONTEND=noninteractive
               apt update && apt install -y curl jq

--- a/pkg/controllers/osc/testdata/osc-kubelet-configuration-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-kubelet-configuration-containerd.yaml
@@ -81,7 +81,7 @@ spec:
       subnetID: test-subnet
       vpcId: e-123f
   osName: ubuntu
-  osVersion: "20.04"
+  osVersion: "24.04"
   provisioningConfig:
     files:
     - content:

--- a/pkg/controllers/osc/testdata/osc-ubuntu-aws-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-aws-containerd.yaml
@@ -81,7 +81,7 @@ spec:
       subnetID: test-subnet
       vpcId: e-123f
   osName: ubuntu
-  osVersion: "20.04"
+  osVersion: "24.04"
   provisioningConfig:
     files:
     - content:

--- a/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack-IPv6+IPv4.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack-IPv6+IPv4.yaml
@@ -81,7 +81,7 @@ spec:
       subnetID: test-subnet
       vpcId: e-123f
   osName: ubuntu
-  osVersion: "20.04"
+  osVersion: "24.04"
   provisioningConfig:
     files:
     - content:

--- a/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack.yaml
@@ -81,7 +81,7 @@ spec:
       subnetID: test-subnet
       vpcId: e-123f
   osName: ubuntu
-  osVersion: "20.04"
+  osVersion: "24.04"
   provisioningConfig:
     files:
     - content:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aims to fix a bug that we ran into with Hetzner machines on Ubuntu 24.04. During our testing cycles for Ubuntu 24.04 support, we found out that DNS somehow stops working after some time; we first thought about removing:

```sh
rm /etc/netplan/50-cloud-init.yaml
```

For Hetzner, it has larger implications, the main one being that dual-stack networking stops working if we remove this line; it was added specifically for that in https://github.com/kubermatic/operating-system-manager/pull/200.

Another side-effect that we found out during testing was that even if we skip this, sometimes the DNS gets broken so early that we are unable to even fetch the provisioning configuration from the Kubernetes secret. 

Hence, to resolve this, we are resorting to Cloudflare DNS as fallback in case the DNS resolution fails.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Resolve DNS resolution issues for Hetzner on Ubuntu 24.04
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
