### PR TITLE
Drop support for Kubernetes v1.28

### DIFF
--- a/deploy/osps/default/osp-amzn2.yaml
+++ b/deploy/osps/default/osp-amzn2.yaml
@@ -219,9 +219,7 @@ spec:
         chown -R root:root "$cni_bin_dir"
 
         {{- /* # cri-tools variables */}}
-        {{- if semverCompare "~1.28.0" .KubeVersion }}
-        CRI_TOOLS_RELEASE="v1.28.0"
-        {{- else if semverCompare "~1.29.0" .KubeVersion }}
+        {{- if semverCompare "~1.29.0" .KubeVersion }}
         CRI_TOOLS_RELEASE="v1.29.0"
         {{- else if semverCompare "~1.30.0" .KubeVersion }}
         CRI_TOOLS_RELEASE="v1.30.1"

--- a/deploy/osps/default/osp-centos.yaml
+++ b/deploy/osps/default/osp-centos.yaml
@@ -235,9 +235,7 @@ spec:
         chown -R root:root "$cni_bin_dir"
 
         {{- /* # cri-tools variables */}}
-        {{- if semverCompare "~1.28.0" .KubeVersion }}
-        CRI_TOOLS_RELEASE="v1.28.0"
-        {{- else if semverCompare "~1.29.0" .KubeVersion }}
+        {{- if semverCompare "~1.29.0" .KubeVersion }}
         CRI_TOOLS_RELEASE="v1.29.0"
         {{- else if semverCompare "~1.30.0" .KubeVersion }}
         CRI_TOOLS_RELEASE="v1.30.1"

--- a/deploy/osps/default/osp-flatcar-cloud-init.yaml
+++ b/deploy/osps/default/osp-flatcar-cloud-init.yaml
@@ -105,9 +105,7 @@ spec:
         chown -R root:root "$cni_bin_dir"
 
         {{- /* # cri-tools variables */}}
-        {{- if semverCompare "~1.28.0" .KubeVersion }}
-        CRI_TOOLS_RELEASE="v1.28.0"
-        {{- else if semverCompare "~1.29.0" .KubeVersion }}
+        {{- if semverCompare "~1.29.0" .KubeVersion }}
         CRI_TOOLS_RELEASE="v1.29.0"
         {{- else if semverCompare "~1.30.0" .KubeVersion }}
         CRI_TOOLS_RELEASE="v1.30.1"

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -254,9 +254,7 @@ spec:
         chown -R root:root "$cni_bin_dir"
 
         {{- /* # cri-tools variables */}}
-        {{- if semverCompare "~1.28.0" .KubeVersion }}
-        CRI_TOOLS_RELEASE="v1.28.0"
-        {{- else if semverCompare "~1.29.0" .KubeVersion }}
+        {{- if semverCompare "~1.29.0" .KubeVersion }}
         CRI_TOOLS_RELEASE="v1.29.0"
         {{- else if semverCompare "~1.30.0" .KubeVersion }}
         CRI_TOOLS_RELEASE="v1.30.1"

--- a/deploy/osps/default/osp-rhel.yaml
+++ b/deploy/osps/default/osp-rhel.yaml
@@ -226,9 +226,7 @@ spec:
         chown -R root:root "$cni_bin_dir"
 
         {{- /* # cri-tools variables */}}
-        {{- if semverCompare "~1.28.0" .KubeVersion }}
-        CRI_TOOLS_RELEASE="v1.28.0"
-        {{- else if semverCompare "~1.29.0" .KubeVersion }}
+        {{- if semverCompare "~1.29.0" .KubeVersion }}
         CRI_TOOLS_RELEASE="v1.29.0"
         {{- else if semverCompare "~1.30.0" .KubeVersion }}
         CRI_TOOLS_RELEASE="v1.30.1"

--- a/deploy/osps/default/osp-rockylinux.yaml
+++ b/deploy/osps/default/osp-rockylinux.yaml
@@ -230,9 +230,7 @@ spec:
         chown -R root:root "$cni_bin_dir"
 
         {{- /* # cri-tools variables */}}
-        {{- if semverCompare "~1.28.0" .KubeVersion }}
-        CRI_TOOLS_RELEASE="v1.28.0"
-        {{- else if semverCompare "~1.29.0" .KubeVersion }}
+        {{- if semverCompare "~1.29.0" .KubeVersion }}
         CRI_TOOLS_RELEASE="v1.29.0"
         {{- else if semverCompare "~1.30.0" .KubeVersion }}
         CRI_TOOLS_RELEASE="v1.30.1"

--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -273,9 +273,7 @@ spec:
         chown -R root:root "$cni_bin_dir"
 
         {{- /* # cri-tools variables */}}
-        {{- if semverCompare "~1.28.0" .KubeVersion }}
-        CRI_TOOLS_RELEASE="v1.28.0"
-        {{- else if semverCompare "~1.29.0" .KubeVersion }}
+        {{- if semverCompare "~1.29.0" .KubeVersion }}
         CRI_TOOLS_RELEASE="v1.29.0"
         {{- else if semverCompare "~1.30.0" .KubeVersion }}
         CRI_TOOLS_RELEASE="v1.30.1"

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -7,7 +7,6 @@ Currently supported K8S versions are:
 - 1.31
 - 1.30
 - 1.29
-- 1.28
 
 ## Operating System
 

--- a/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
+++ b/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
@@ -215,9 +215,7 @@ spec:
         chown -R root:root "$cni_bin_dir"
 
         {{- /* # cri-tools variables */}}
-        {{- if semverCompare "~1.28.0" .KubeVersion }}
-        CRI_TOOLS_RELEASE="v1.28.0"
-        {{- else if semverCompare "~1.29.0" .KubeVersion }}
+        {{- if semverCompare "~1.29.0" .KubeVersion }}
         CRI_TOOLS_RELEASE="v1.29.0"
         {{- else if semverCompare "~1.30.0" .KubeVersion }}
         CRI_TOOLS_RELEASE="v1.30.0"


### PR DESCRIPTION
**What this PR does / why we need it**:
Active support for Kubernetes v1.28 is over and maintenance support ends on 28 Oct 2024. 

https://endoflife.date/kubernetes

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support for Kubernetes v1.28 has been removed
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
