### PR TITLE
[release/v1.6] bump OSPs to 1.6.2

### DIFF
--- a/deploy/osps/default/osp-amzn2.yaml
+++ b/deploy/osps/default/osp-amzn2.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "amzn2"
   osVersion: "2.0"
-  version: "v1.6.0"
+  version: "v1.6.2"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-flatcar-cloud-init.yaml
+++ b/deploy/osps/default/osp-flatcar-cloud-init.yaml
@@ -21,7 +21,7 @@ spec:
   osName: flatcar
   ## Flatcar Stable (09/11/2021)
   osVersion: "2983.2.0"
-  version: "v1.6.0"
+  version: "v1.6.2"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "anexia"

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -21,7 +21,7 @@ spec:
   osName: flatcar
   ## Flatcar Stable (09/11/2021)
   osVersion: "2983.2.0"
-  version: "v1.6.0"
+  version: "v1.6.2"
   provisioningUtility: "ignition"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-rhel.yaml
+++ b/deploy/osps/default/osp-rhel.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "rhel"
   osVersion: "8.5"
-  version: "v1.6.0"
+  version: "v1.6.2"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-rockylinux.yaml
+++ b/deploy/osps/default/osp-rockylinux.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "rockylinux"
   osVersion: "8.6"
-  version: "v1.6.0"
+  version: "v1.6.2"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "ubuntu"
   osVersion: "24.04"
-  version: "v1.6.0"
+  version: "v1.6.2"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "alibaba"

--- a/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
+++ b/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "rhel"
   osVersion: "8.5"
-  version: "v1.6.0"
+  version: "v1.6.2"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"

--- a/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Operating System Manager contributors.
+Copyright 2025 The Operating System Manager contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What this PR does / why we need it**:
I forgot to adjust them for the previous release, so 1.6.1 is not a good release and will be superseded by 1.6.2.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix outdated OSP versions, preventing automated upgrades from 1.6.0 to 1.6.1.
```

**Documentation**:
```documentation
NONE
```
