### PR TITLE
Support Disabling Default OSPS Creation

### DIFF
--- a/cmd/osm-controller/main.go
+++ b/cmd/osm-controller/main.go
@@ -71,6 +71,7 @@ type options struct {
 	workerClusterKubeconfig string
 	kubeconfig              string
 	kubeletFeatureGates     string
+	disableDefaultOSPs      bool
 
 	healthProbeAddress       string
 	metricsAddress           string
@@ -121,6 +122,7 @@ func main() {
 	flag.StringVar(&opt.clusterDNSIPs, "cluster-dns", "10.10.10.10", "Comma-separated list of DNS server IP address.")
 	flag.StringVar(&opt.pauseImage, "pause-image", "", "pause image to use in Kubelet.")
 	flag.StringVar(&opt.initialTaints, "initial-taints", "", "taints to use when creating the node.")
+	flag.BoolVar(&opt.disableDefaultOSPs, "disable-default-osps", false, "disable the creation of the default osps and only rely on custom osps.")
 
 	flag.StringVar(&opt.kubeletFeatureGates, "node-kubelet-feature-gates", "RotateKubeletServerCertificate=true", "Feature gates to set on the kubelet")
 
@@ -291,7 +293,7 @@ func main() {
 	providerconfig.SetConfigVarResolver(context.Background(), workerMgr.GetClient(), opt.namespace)
 
 	// Setup OSP controller
-	if err := osp.Add(mgr, log, opt.namespace, opt.workerCount); err != nil {
+	if err := osp.Add(mgr, log, opt.namespace, opt.workerCount, opt.disableDefaultOSPs); err != nil {
 		log.Fatal(err)
 	}
 

--- a/pkg/controllers/osp/osp_controller.go
+++ b/pkg/controllers/osp/osp_controller.go
@@ -58,7 +58,13 @@ type Reconciler struct {
 	namespace string
 }
 
-func Add(mgr manager.Manager, log *zap.SugaredLogger, namespace string, workerCount int) error {
+func Add(mgr manager.Manager, log *zap.SugaredLogger, namespace string, workerCount int, disableDefaultOSPs bool) error {
+	// if the default osps creation is disabled then there is no need to load the default osps and only custom osps
+	// should be used.
+	if disableDefaultOSPs {
+		return nil
+	}
+
 	defaultOSPs, err := loadDefaultOSPs()
 	if err != nil {
 		return fmt.Errorf("failed to load default OSPs: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR disables the creation of the default OSPs. This is pretty useful in the air-gapped and offline envs where the default OSPs won't be used and only custom OSPs will be used. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Disabling the creation of the default OSPs 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
