### PR TITLE
Update to Go 1.24.2, golangci-lint 2.x

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,9 @@
 # limitations under the License.
 version: "2"
 run:
+  # concurrency=1 lowers memory usage a bit
+  concurrency: 1
+  modules-download-mode: readonly
   issues-exit-code: 1
 
 linters:
@@ -30,8 +33,6 @@ linters:
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - gosimple
     - govet
     - importas
     - ineffassign
@@ -43,34 +44,81 @@ linters:
     - nosprintfhostport
     - predeclared
     - promlinter
-    - revive
     - staticcheck
-    - tenv
     - unconvert
     - unused
     - wastedassign
     - whitespace
 
-linters-settings:
-  goimports:
-    local-prefixes: k8c.io/operating-system-manager
-  tagliatelle:
-    case:
+  settings:
+    goimports:
+      local-prefixes: k8c.io/operating-system-manager
+    tagliatelle:
+      case:
+        rules:
+          json: goCamel
+          yaml: goCamel
+    depguard:
       rules:
-        json: goCamel
-        yaml: goCamel
-  depguard:
-    rules:
-      main:
-        deny:
-          - { pkg: io/ioutil, desc: https://go.dev/doc/go1.16#ioutil }
-  govet:
-    enable:
-      - nilness # find tautologies / impossible conditions
+        main:
+          deny:
+            - { pkg: io/ioutil, desc: https://go.dev/doc/go1.16#ioutil }
+    govet:
+      enable:
+        - nilness # find tautologies / impossible conditions
+    importas:
+      alias:
+        # Operating System Manager
+        - pkg: k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1
+          alias: osmv1alpha1
+        - pkg: k8c.io/operating-system-manager/pkg/test/util
+          alias: testUtil
+        # Machine Controller
+        - pkg: k8c.io/machine-controller/sdk/apis/(\w+)/(v[\w\d]+)
+          alias: $1$2
+        - pkg: k8c.io/machine-controller/sdk/bootstrap
+          alias: mcbootstrap
+        - pkg: k8c.io/machine-controller/sdk/net
+          alias: mcnet
+        - pkg: k8c.io/machine-controller/pkg/controller/util
+          alias: machinecontrollerutil
+        # Kubernetes
+        - pkg: k8s.io/api/(\w+)/(v[\w\d]+)
+          alias: $1$2
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+          alias: apiextensionsv1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: kerrors
+        # Controller Runtime
+        - pkg: sigs.k8s.io/controller-runtime/pkg/client
+          alias: ctrlruntimeclient
+        - pkg: sigs.k8s.io/controller-runtime/pkg/client/fake
+          alias: ctrlruntimefakeclient
+    staticcheck:
+      checks:
+        - all
+        - '-ST1000'
+        - '-QF1008'
+        - '-ST1020'
+  exclusions:
+    presets:
+      - comments
+      - std-error-handling
+      - common-false-positives
+      - legacy
+    paths:
+      - zz_generated.*.go
 
 issues:
-  exclude-dirs:
-    - hack
-    - vendor
-  exclude-files:
-    - zz_generated.*.go
+  max-same-issues: 0
+
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    paths:
+      - zz_generated.*.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 version: "2"
 run:
   # concurrency=1 lowers memory usage a bit

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+version: "2"
 run:
-  timeout: 20m
   issues-exit-code: 1
 
 linters:
+  default: none
   enable:
     - asasalint
     - asciicheck
@@ -45,12 +46,10 @@ linters:
     - revive
     - staticcheck
     - tenv
-    - typecheck
     - unconvert
     - unused
     - wastedassign
     - whitespace
-  disable-all: true
 
 linters-settings:
   goimports:

--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -26,7 +26,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-5
           command:
             - /bin/bash
             - -c
@@ -53,7 +53,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-5
           command:
             - "./hack/ci/upload-gocache.sh"
           resources:

--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -26,7 +26,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-4
           command:
             - /bin/bash
             - -c
@@ -53,7 +53,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-4
           command:
             - "./hack/ci/upload-gocache.sh"
           resources:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-5
           command:
             - make
           args:
@@ -36,7 +36,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-5
           command:
             - make
           args:
@@ -58,7 +58,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-5
           command:
             - make
           args:
@@ -79,7 +79,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-5
           command:
             - ./hack/verify-licenses.sh
           resources:
@@ -95,7 +95,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-5
           command:
             - make
           args:
@@ -115,7 +115,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-5
           command:
             - make
           args:
@@ -130,7 +130,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/operating-system-manager.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-5
           command:
             - shfmt
           args:
@@ -161,7 +161,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-5
           command:
             - make
           args:
@@ -182,7 +182,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-5
           command:
             - "./hack/ci/run-e2e-tests.sh"
           resources:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-4
           command:
             - make
           args:
@@ -36,7 +36,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-4
           command:
             - make
           args:
@@ -58,7 +58,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-4
           command:
             - make
           args:
@@ -79,7 +79,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-4
           command:
             - ./hack/verify-licenses.sh
           resources:
@@ -95,7 +95,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-4
           command:
             - make
           args:
@@ -115,7 +115,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-4
           command:
             - make
           args:
@@ -130,7 +130,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/operating-system-manager.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-4
           command:
             - shfmt
           args:
@@ -161,7 +161,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-4
           command:
             - make
           args:
@@ -182,7 +182,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-4
           command:
             - "./hack/ci/run-e2e-tests.sh"
           resources:

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -109,7 +109,7 @@ is_containerized() {
 
 containerize() {
   local cmd="$1"
-  local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:2.0.0}"
+  local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:2.6.0}"
   local gocache="${CONTAINERIZE_GOCACHE:-/tmp/.gocache}"
   local gomodcache="${CONTAINERIZE_GOMODCACHE:-/tmp/.gomodcache}"
   local skip="${NO_CONTAINERIZE:-}"

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-4 containerize ./hack/update-codegen.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-5 containerize ./hack/update-codegen.sh
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 
 sed="sed"

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-10 containerize ./hack/update-codegen.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-4 containerize ./hack/update-codegen.sh
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 
 sed="sed"

--- a/hack/update-crds-openapi.sh
+++ b/hack/update-crds-openapi.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-4 containerize ./hack/update-crds-openapi.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-5 containerize ./hack/update-crds-openapi.sh
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 
 echodate "Creating vendor directory"

--- a/hack/update-crds-openapi.sh
+++ b/hack/update-crds-openapi.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-10 containerize ./hack/update-crds-openapi.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-4 containerize ./hack/update-crds-openapi.sh
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 
 echodate "Creating vendor directory"

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-10 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-4 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-4 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-5 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/pkg/bootstrap/kubeconfig_test.go
+++ b/pkg/bootstrap/kubeconfig_test.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	ctrlruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestUpdateSecretExpirationAndGetToken(t *testing.T) {
@@ -60,7 +60,7 @@ func TestUpdateSecretExpirationAndGetToken(t *testing.T) {
 		data[tokenIDKey] = []byte("tokenID")
 		data[expirationKey] = []byte(testCase.initialExpirationTime.Format(time.RFC3339))
 		secret.Data = data
-		b.client = ctrlruntimefake.
+		b.client = ctrlruntimefakeclient.
 			NewClientBuilder().
 			WithScheme(scheme.Scheme).
 			WithObjects(secret).

--- a/pkg/clusterinfo/configmap.go
+++ b/pkg/clusterinfo/configmap.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/klog/v2"
-	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -38,7 +38,7 @@ const (
 	securePortName          = "https"
 )
 
-func New(client controllerruntimeclient.Client, caCert string) *KubeconfigProvider {
+func New(client ctrlruntimeclient.Client, caCert string) *KubeconfigProvider {
 	return &KubeconfigProvider{
 		client: client,
 		caCert: caCert,
@@ -47,7 +47,7 @@ func New(client controllerruntimeclient.Client, caCert string) *KubeconfigProvid
 
 type KubeconfigProvider struct {
 	caCert string
-	client controllerruntimeclient.Client
+	client ctrlruntimeclient.Client
 }
 
 func (p *KubeconfigProvider) GetKubeconfig(ctx context.Context) (*clientcmdapi.Config, error) {

--- a/pkg/clusterinfo/configmap_test.go
+++ b/pkg/clusterinfo/configmap_test.go
@@ -28,8 +28,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	ctrlruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const (
@@ -62,14 +62,14 @@ users: null
 func TestKubeconfigProvider_GetKubeconfig(t *testing.T) {
 	tests := []struct {
 		name         string
-		objects      []controllerruntimeclient.Object
+		objects      []ctrlruntimeclient.Object
 		clientConfig *rest.Config
 		err          error
 		resConfig    string
 	}{
 		{
 			name: "successful from configmap",
-			objects: []controllerruntimeclient.Object{&corev1.ConfigMap{
+			objects: []ctrlruntimeclient.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cluster-info",
 					Namespace: "kube-public",
@@ -82,7 +82,7 @@ func TestKubeconfigProvider_GetKubeconfig(t *testing.T) {
 		},
 		{
 			name: "successful from in-cluster via endpoints - clusterIP",
-			objects: []controllerruntimeclient.Object{&corev1.Endpoints{
+			objects: []ctrlruntimeclient.Object{&corev1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kubernetes",
 					Namespace: "default",
@@ -118,7 +118,7 @@ func TestKubeconfigProvider_GetKubeconfig(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
-			client := ctrlruntimefake.
+			client := ctrlruntimefakeclient.
 				NewClientBuilder().
 				WithScheme(scheme.Scheme).
 				WithObjects(test.objects...).

--- a/pkg/controllers/osc/osc_reconciler_test.go
+++ b/pkg/controllers/osc/osc_reconciler_test.go
@@ -46,8 +46,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 )
 
@@ -283,7 +283,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		if err := loadFile(osp, testCase.ospFile); err != nil {
 			t.Fatalf("failed loading osp %s from testdata: %v", testCase.name, err)
 		}
-		objects := []controllerruntimeclient.Object{
+		objects := []ctrlruntimeclient.Object{
 			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cluster-info",
@@ -316,7 +316,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 
 		objects = append(objects, osp)
 
-		fakeClient := fakectrlruntimeclient.
+		fakeClient := ctrlruntimefakeclient.
 			NewClientBuilder().
 			WithScheme(scheme.Scheme).
 			WithObjects(objects...).
@@ -463,7 +463,7 @@ func TestOSCAndSecretRotation(t *testing.T) {
 			t.Fatalf("failed loading osp %s from testdata: %v", testCase.name, err)
 		}
 
-		objects := []controllerruntimeclient.Object{
+		objects := []ctrlruntimeclient.Object{
 			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cluster-info",
@@ -499,7 +499,7 @@ func TestOSCAndSecretRotation(t *testing.T) {
 		objects = append(objects, osp)
 		objects = append(objects, md)
 
-		fakeClient := fakectrlruntimeclient.
+		fakeClient := ctrlruntimefakeclient.
 			NewClientBuilder().
 			WithScheme(scheme.Scheme).
 			WithObjects(objects...).
@@ -659,7 +659,7 @@ func TestMachineDeploymentDeletion(t *testing.T) {
 			t.Fatalf("failed loading osp %s from testdata: %v", testCase.name, err)
 		}
 
-		objects := []controllerruntimeclient.Object{
+		objects := []ctrlruntimeclient.Object{
 			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cluster-info",
@@ -695,7 +695,7 @@ func TestMachineDeploymentDeletion(t *testing.T) {
 		objects = append(objects, osp)
 		objects = append(objects, md)
 
-		fakeClient := fakectrlruntimeclient.
+		fakeClient := ctrlruntimefakeclient.
 			NewClientBuilder().
 			WithScheme(scheme.Scheme).
 			WithObjects(objects...).
@@ -834,7 +834,7 @@ func loadFile(obj runtime.Object, name string) error {
 	return nil
 }
 
-func buildReconciler(fakeClient controllerruntimeclient.Client, config testConfig) Reconciler {
+func buildReconciler(fakeClient ctrlruntimeclient.Client, config testConfig) Reconciler {
 	kubeconfigProvider := clusterinfo.New(fakeClient, "foobar")
 	bootstrappingManager := bootstrap.New(fakeClient, kubeconfigProvider, nil, "")
 	featureGates := map[string]bool{"GracefulNodeShutdown": true, "IdentifyPodOS": false}


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps the repository to Go 1.24 and the new golangci-lint. I migrated its config and adjusted the code now that staticcheck's integration has been improved and more of it became visible.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update to Go 1.24.2
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
