### PR TITLE
feat: add support for gVisor runtime

### DIFF
--- a/cmd/osm-controller/main.go
+++ b/cmd/osm-controller/main.go
@@ -83,6 +83,7 @@ type options struct {
 	nodeRegistryMirrors           string
 	nodeRegistryCredentialsSecret string
 	nodeContainerdRegistryMirrors containerruntime.RegistryMirrorsFlags
+	containerdGVisorRuntime       string
 
 	// Flags for proxy
 	nodeHTTPProxy string
@@ -130,6 +131,7 @@ func main() {
 	flag.StringVar(&opt.nodeNoProxy, "node-no-proxy", ".svc,.cluster.local,localhost,127.0.0.1", "If set, it configures the 'NO_PROXY' environment variable on the nodes.")
 	flag.StringVar(&opt.nodeInsecureRegistries, "node-insecure-registries", "", "Comma separated list of registries which should be configured as insecure on the container runtime")
 	flag.StringVar(&opt.nodeRegistryMirrors, "node-registry-mirrors", "", "Comma separated list of Docker image mirrors")
+	flag.StringVar(&opt.containerdGVisorRuntime, "containerd-gvisor-runtime", "", "Runtime to use for gVisor/runsc. Typically \"io.containerd.runsc.v1\". Omit to disable.")
 
 	if opt.nodeContainerdRegistryMirrors == nil {
 		opt.nodeContainerdRegistryMirrors = containerruntime.RegistryMirrorsFlags{}
@@ -222,6 +224,7 @@ func main() {
 		PauseImage:                opt.pauseImage,
 		RegistryMirrors:           opt.nodeRegistryMirrors,
 		RegistryCredentialsSecret: opt.nodeRegistryCredentialsSecret,
+		GVisorRuntime:             opt.containerdGVisorRuntime,
 	}
 	containerRuntimeConfig, err := containerruntime.BuildConfig(containerRuntimeOpts)
 	if err != nil {

--- a/pkg/containerruntime/config.go
+++ b/pkg/containerruntime/config.go
@@ -36,6 +36,7 @@ type Opts struct {
 	RegistryMirrors           string
 	RegistryCredentialsSecret string
 	PauseImage                string
+	GVisorRuntime             string
 	ContainerdRegistryMirrors RegistryMirrorsFlags
 }
 
@@ -98,6 +99,7 @@ func BuildConfig(opts Opts) (Config, error) {
 		withRegistryMirrors(opts.ContainerdRegistryMirrors),
 		withSandboxImage(opts.PauseImage),
 		withContainerdVersion(opts.ContainerdVersion),
+		withGVisor(opts.GVisorRuntime),
 	), nil
 }
 

--- a/pkg/containerruntime/containerd.go
+++ b/pkg/containerruntime/containerd.go
@@ -27,6 +27,7 @@ type Containerd struct {
 	registryMirrors     map[string][]string
 	sandboxImage        string
 	registryCredentials map[string]AuthConfig
+	gVisorRuntime       string
 	version             string
 }
 
@@ -119,6 +120,13 @@ func (eng *Containerd) Config() (string, error) {
 				},
 			},
 		},
+	}
+
+	// https://gvisor.dev/docs/user_guide/containerd/quick_start/
+	if eng.gVisorRuntime != "" {
+		criPlugin.Containerd.Runtimes["runsc"] = containerdCRIRuntime{
+			RuntimeType: eng.gVisorRuntime,
+		}
 	}
 
 	for registryName := range eng.registryMirrors {

--- a/pkg/containerruntime/containerruntime.go
+++ b/pkg/containerruntime/containerruntime.go
@@ -55,6 +55,12 @@ func withContainerdVersion(version string) Opt {
 	}
 }
 
+func withGVisor(runtime string) Opt {
+	return func(cfg *Config) {
+		cfg.GVisorRuntime = runtime
+	}
+}
+
 func get(_ string, opts ...Opt) Config {
 	cfg := Config{}
 	cfg.Containerd = &Containerd{}
@@ -75,6 +81,7 @@ type Config struct {
 	ContainerLogMaxFiles string                `json:",omitempty"`
 	ContainerLogMaxSize  string                `json:",omitempty"`
 	ContainerdVersion    string                `json:",omitempty"`
+	GVisorRuntime        string                `json:",omitempty"`
 }
 
 // AuthConfig is a COPY of github.com/containerd/containerd/pkg/cri/config.AuthConfig.
@@ -103,6 +110,7 @@ func (cfg Config) Engine() Engine {
 		sandboxImage:        cfg.SandboxImage,
 		registryCredentials: cfg.RegistryCredentials,
 		version:             cfg.ContainerdVersion,
+		enableGVisor:        cfg.GVisorRuntime,
 	}
 	return containerd
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Handles the "configure containerd" part of [setting up gVisor](https://gvisor.dev/docs/user_guide/containerd/quick_start/), since it can't be cleanly done in an OSP.

**What type of PR is this?**

/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds `--containerd-gvisor-runtime` flag, which, if set, adds a `runsc` runtime with the given runtime type (typically `io.containerd.runsc.v1`) to the containerd config.
```

**Documentation**:

https://gvisor.dev/docs/user_guide/containerd/quick_start/
