### PR TITLE
Bump the Go build image version to v1.24.4

### DIFF
--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -26,7 +26,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-5
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-6
           command:
             - /bin/bash
             - -c
@@ -53,7 +53,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-5
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-6
           command:
             - "./hack/ci/upload-gocache.sh"
           resources:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-5
+        - image: quay.io/kubermatic/build:go-1.24-node-20-6
           command:
             - make
           args:
@@ -36,7 +36,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-5
+        - image: quay.io/kubermatic/build:go-1.24-node-20-6
           command:
             - make
           args:
@@ -58,7 +58,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-5
+        - image: quay.io/kubermatic/build:go-1.24-node-20-6
           command:
             - make
           args:
@@ -79,7 +79,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-5
+        - image: quay.io/kubermatic/build:go-1.24-node-20-6
           command:
             - ./hack/verify-licenses.sh
           resources:
@@ -95,7 +95,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-5
+        - image: quay.io/kubermatic/build:go-1.24-node-20-6
           command:
             - make
           args:
@@ -115,7 +115,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-5
+        - image: quay.io/kubermatic/build:go-1.24-node-20-6
           command:
             - make
           args:
@@ -130,7 +130,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/operating-system-manager.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-5
+        - image: quay.io/kubermatic/build:go-1.24-node-20-6
           command:
             - shfmt
           args:
@@ -161,7 +161,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-5
+        - image: quay.io/kubermatic/build:go-1.24-node-20-6
           command:
             - make
           args:
@@ -182,7 +182,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-5
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-6
           command:
             - "./hack/ci/run-e2e-tests.sh"
           resources:

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-5 containerize ./hack/update-codegen.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-6 containerize ./hack/update-codegen.sh
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 
 sed="sed"

--- a/hack/update-crds-openapi.sh
+++ b/hack/update-crds-openapi.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-5 containerize ./hack/update-crds-openapi.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-6 containerize ./hack/update-crds-openapi.sh
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 
 echodate "Creating vendor directory"

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-5 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-6 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to bump the Go build image version to v1.24.4.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
