### PR TITLE
vmware cloud director multi nic configuration

### DIFF
--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -79,7 +79,7 @@ spec:
           local number_of_bits_from_conversion_table=$((len_right_stripped_conversion_table/4))
           echo $(( $number_of_bits_stripped + $number_of_bits_from_conversion_table ))
         }
-        
+
         nicByMac () {
           local MAC=$1
           echo $(ip -br link | grep "${MAC}" | awk '{print $1}')
@@ -87,8 +87,8 @@ spec:
 
         PRIMARY_NIC=$(query_ovf "vCloud_primaryNic")
         NIC_COUNT=$(query_ovf "vCloud_numnics")
-        
-        
+
+
         for i in $(seq 0 $((NIC_COUNT - 1))); do
           IP_MODE=$(query_ovf "vCloud_bootproto_${i}")
 
@@ -114,7 +114,7 @@ spec:
               echo "DNS= ${DNS1} ${DNS2}" >> /etc/systemd/network/0${i}-${INTERFACE}.network
             fi
           fi
-          
+
         done
 
       configureHostCABundle: |-


### PR DESCRIPTION
**What this PR does / why we need it**:
With the machine controller pr https://github.com/kubermatic/machine-controller/pull/1941 it gets possible to deploy nodes with multiple nics. This pr enhances the bootstrap script for static networking, to configure secondary nics aswell.


**Which issue(s) this PR fixes**:
-

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
VMware cloud director flatcar nodes will now configure multiple nics, with static networking
```

**Documentation**:
```documentation
TBD
```
