### PR TITLE
change drop-ins to drop_ins

### DIFF
--- a/deploy/crd/operatingsystemmanager.k8c.io_operatingsystemconfigs.yaml
+++ b/deploy/crd/operatingsystemmanager.k8c.io_operatingsystemconfigs.yaml
@@ -136,7 +136,7 @@ spec:
                           description: Content is the unit's content.
                           type: string
                         dropIns:
-                          description: DropIns is a list of drop-ins for this unit.
+                          description: DropIns is a list of drop_ins for this unit.
                           items:
                             description: DropIn is a drop-in configuration for a systemd
                               unit.
@@ -314,7 +314,7 @@ spec:
                           description: Content is the unit's content.
                           type: string
                         dropIns:
-                          description: DropIns is a list of drop-ins for this unit.
+                          description: DropIns is a list of drop_ins for this unit.
                           items:
                             description: DropIn is a drop-in configuration for a systemd
                               unit.

--- a/deploy/crd/operatingsystemmanager.k8c.io_operatingsystemprofiles.yaml
+++ b/deploy/crd/operatingsystemmanager.k8c.io_operatingsystemprofiles.yaml
@@ -208,7 +208,7 @@ spec:
                           description: Content is the unit's content.
                           type: string
                         dropIns:
-                          description: DropIns is a list of drop-ins for this unit.
+                          description: DropIns is a list of drop_ins for this unit.
                           items:
                             description: DropIn is a drop-in configuration for a systemd
                               unit.
@@ -417,7 +417,7 @@ spec:
                           description: Content is the unit's content.
                           type: string
                         dropIns:
-                          description: DropIns is a list of drop-ins for this unit.
+                          description: DropIns is a list of drop_ins for this unit.
                           items:
                             description: DropIn is a drop-in configuration for a systemd
                               unit.

--- a/hack/kkp/operatingsystemmanager.k8c.io_customoperatingsystemprofiles.yaml
+++ b/hack/kkp/operatingsystemmanager.k8c.io_customoperatingsystemprofiles.yaml
@@ -201,7 +201,7 @@ spec:
                             description: Content is the unit's content.
                             type: string
                           dropIns:
-                            description: DropIns is a list of drop-ins for this unit.
+                            description: DropIns is a list of drop_ins for this unit.
                             items:
                               description: DropIn is a drop-in configuration for a systemd unit.
                               properties:
@@ -387,7 +387,7 @@ spec:
                             description: Content is the unit's content.
                             type: string
                           dropIns:
-                            description: DropIns is a list of drop-ins for this unit.
+                            description: DropIns is a list of drop_ins for this unit.
                             items:
                               description: DropIn is a drop-in configuration for a systemd unit.
                               properties:

--- a/pkg/crd/osm/v1alpha1/common_types.go
+++ b/pkg/crd/osm/v1alpha1/common_types.go
@@ -96,7 +96,7 @@ type Unit struct {
 	Mask *bool `json:"mask,omitempty"`
 	// Content is the unit's content.
 	Content *string `json:"content,omitempty"`
-	// DropIns is a list of drop-ins for this unit.
+	// DropIns is a list of drop_ins for this unit.
 	DropIns []DropIn `json:"dropIns,omitempty"`
 }
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -258,7 +258,7 @@ coreos:
 {{ $unit.Content | indent 6 }}
 {{- end }}
 {{ if $unit.Content }}
-    drop-ins:
+    drop_ins:
 {{- range $_, $dropIn := $unit.DropIns }}
       - name: "{{ $dropIn.Name }}"
         content: |


### PR DESCRIPTION
**What this PR does / why we need it**:
CoreOS Cloud Init is not reading the drop-ins sections in cloud-config.yml since Flatcar 3975.2.0.

**Which issue(s) this PR fixes**:
Fixes https://github.com/flatcar/Flatcar/issues/1567

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
