### PR TITLE
Flatcar optimize network configuration speed on vmware cloud director

### DIFF
--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -343,10 +343,13 @@ spec:
         content: |
           [Install]
           WantedBy=multi-user.target
+          
+          {{- if not (eq .CloudProviderName "vmware-cloud-director") }}
 
           [Unit]
           Requires=network-online.target
           After=network-online.target
+          {{- end }}
 
           [Service]
           Type=oneshot

--- a/pkg/controllers/osc/resources/operating_system_config.go
+++ b/pkg/controllers/osc/resources/operating_system_config.go
@@ -234,7 +234,17 @@ func GenerateOperatingSystemConfig(
 	// Render files for provisioning config
 	renderedProvisioningFiles, err := renderedFiles(osp.Spec.ProvisioningConfig, containerRuntime, data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to render bootstrapping file templates: %w", err)
+		return nil, fmt.Errorf("failed to render provisioning file templates: %w", err)
+	}
+
+	renderedBootstrappingUnits, err := renederedUnits(osp.Spec.BootstrapConfig, data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to render bootstrapping Unit templates: %w", err)
+	}
+
+	renderedProvisioningUnits, err := renederedUnits(osp.Spec.ProvisioningConfig, data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to render provisioning Unit templates: %w", err)
 	}
 
 	osc.Spec = osmv1alpha1.OperatingSystemConfigSpec{
@@ -245,13 +255,13 @@ func GenerateOperatingSystemConfig(
 			Spec: providerConfig.CloudProviderSpec,
 		},
 		BootstrapConfig: osmv1alpha1.OSCConfig{
-			Units:            ospOriginal.Spec.BootstrapConfig.Units,
+			Units:            renderedBootstrappingUnits,
 			Files:            renderedBootstrappingFiles,
 			UserSSHKeys:      providerConfig.SSHPublicKeys,
 			CloudInitModules: osp.Spec.BootstrapConfig.CloudInitModules,
 		},
 		ProvisioningConfig: osmv1alpha1.OSCConfig{
-			Units:            ospOriginal.Spec.ProvisioningConfig.Units,
+			Units:            renderedProvisioningUnits,
 			Files:            renderedProvisioningFiles,
 			UserSSHKeys:      providerConfig.SSHPublicKeys,
 			CloudInitModules: osp.Spec.ProvisioningConfig.CloudInitModules,
@@ -409,6 +419,38 @@ func selectAdditionalTemplates(config osmv1alpha1.OSPConfig, containerRuntime st
 	}
 
 	return templates, nil
+}
+
+func renederedUnits(config osmv1alpha1.OSPConfig, data filesData) ([]osmv1alpha1.Unit, error) {
+	populatedUnits, err := populateUnitList(config.Units, data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to populate OSP Unit template: %w", err)
+	}
+	return populatedUnits, nil
+}
+
+func populateUnitList(units []osmv1alpha1.Unit, d filesData) ([]osmv1alpha1.Unit, error) {
+	funcMap := fm.ExtraTxtFuncMap()
+	var punits []osmv1alpha1.Unit
+	for _, unit := range units {
+		content := unit.Content
+		tmpl, err := template.New(unit.Name).Funcs(funcMap).Parse(*content)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse OSP Unit [%s] template: %w", unit.Name, err)
+		}
+
+		buff := bytes.Buffer{}
+		if err := tmpl.Execute(&buff, &d); err != nil {
+			return nil, err
+		}
+		pcontent := buff.String()
+		punit := unit.DeepCopy()
+		punit.Content = &pcontent
+
+		punits = append(punits, *punit)
+	}
+
+	return punits, nil
 }
 
 func addTemplatingSequence(templateName, template string) string {


### PR DESCRIPTION
Dont wait for network when using flatcar on vmware-cloud-director, as bootstrap script configures network. To achieve this, template support for unit files was added. This reduces bootstrapping time alot, as waiting for network times out currently

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Flatcar Vmware cloud director, bootstrap time improved
```

**Documentation**:

```documentation
NONE
```
