### PR TITLE
Add missing "update" permission for secrets to rbac-controller

### DIFF
--- a/deploy/rbac-controller.yaml
+++ b/deploy/rbac-controller.yaml
@@ -62,6 +62,7 @@ rules:
       - secrets
     verbs:
       - get
+      - update
       - list
       - create
       - delete


### PR DESCRIPTION
**What this PR does / why we need it**:

When running OSM on the infrastructure of the seed cluster, we noticed that the logs of the OSM reported the following line:

    {"level":"error","time":"2025-07-22T08:49:41.696Z","caller":"controller/controller.go:294","msg":"Reconciler error","controller":"operating-system-config-controller","controllerGroup":"cluster.k8s.io","controllerKind":"MachineDeployment","MachineDeployment":{"name":"kubermatic-dev-seed0401-worker-a","namespace":"kube-system"},"namespace":"kube-system","name":"kubermatic-dev-seed0401-worker-a","reconcileID":"1edef5bf-9017-4588-beaf-f0bbc11e6922","error":"failed to reconcile operating system config: failed to create bootstrap kubeconfig: secrets \"kube-system-kubermatic-dev-seed0401-worker-a-kubelet-bootstrap-config\" is forbidden: User \"system:serviceaccount:kube-system:operating-system-manager\" cannot update resource \"secrets\" in API group \"\" in the namespace \"cloud-init-settings\""}

Because of that, newly initialised machines could not fetch the appropriate config, kubelet reported errors like:

    Unable to register node with API server, error getting existing node. User "system:anonymous" cannot get resource "nodes"...

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add missing "update" permission to Secrets in `cloud-init`
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
