### PR TITLE
add option for containerd non-root device usage flag

### DIFF
--- a/cmd/osm-controller/main.go
+++ b/cmd/osm-controller/main.go
@@ -79,10 +79,11 @@ type options struct {
 	workerMetricsAddress     string
 
 	// Flags for configuring CRI
-	nodeInsecureRegistries        string
-	nodeRegistryMirrors           string
-	nodeRegistryCredentialsSecret string
-	nodeContainerdRegistryMirrors containerruntime.RegistryMirrorsFlags
+	nodeInsecureRegistries             string
+	nodeRegistryMirrors                string
+	nodeRegistryCredentialsSecret      string
+	nodeContainerdRegistryMirrors      containerruntime.RegistryMirrorsFlags
+	deviceOwnershipFromSecurityContext bool
 
 	// Flags for proxy
 	nodeHTTPProxy string
@@ -130,6 +131,7 @@ func main() {
 	flag.StringVar(&opt.nodeNoProxy, "node-no-proxy", ".svc,.cluster.local,localhost,127.0.0.1", "If set, it configures the 'NO_PROXY' environment variable on the nodes.")
 	flag.StringVar(&opt.nodeInsecureRegistries, "node-insecure-registries", "", "Comma separated list of registries which should be configured as insecure on the container runtime")
 	flag.StringVar(&opt.nodeRegistryMirrors, "node-registry-mirrors", "", "Comma separated list of Docker image mirrors")
+	flag.BoolVar(&opt.deviceOwnershipFromSecurityContext, "device-ownership-from-security-context", false, "Enable non-root device usage")
 
 	if opt.nodeContainerdRegistryMirrors == nil {
 		opt.nodeContainerdRegistryMirrors = containerruntime.RegistryMirrorsFlags{}
@@ -216,12 +218,13 @@ func main() {
 
 	// Build container-runtime configuration
 	containerRuntimeOpts := containerruntime.Opts{
-		ContainerRuntime:          opt.containerRuntime,
-		ContainerdRegistryMirrors: opt.nodeContainerdRegistryMirrors,
-		InsecureRegistries:        opt.nodeInsecureRegistries,
-		PauseImage:                opt.pauseImage,
-		RegistryMirrors:           opt.nodeRegistryMirrors,
-		RegistryCredentialsSecret: opt.nodeRegistryCredentialsSecret,
+		ContainerRuntime:                   opt.containerRuntime,
+		ContainerdRegistryMirrors:          opt.nodeContainerdRegistryMirrors,
+		InsecureRegistries:                 opt.nodeInsecureRegistries,
+		PauseImage:                         opt.pauseImage,
+		RegistryMirrors:                    opt.nodeRegistryMirrors,
+		RegistryCredentialsSecret:          opt.nodeRegistryCredentialsSecret,
+		DeviceOwnershipFromSecurityContext: opt.deviceOwnershipFromSecurityContext,
 	}
 	containerRuntimeConfig, err := containerruntime.BuildConfig(containerRuntimeOpts)
 	if err != nil {

--- a/pkg/containerruntime/config.go
+++ b/pkg/containerruntime/config.go
@@ -30,13 +30,14 @@ import (
 )
 
 type Opts struct {
-	ContainerRuntime          string
-	ContainerdVersion         string
-	InsecureRegistries        string
-	RegistryMirrors           string
-	RegistryCredentialsSecret string
-	PauseImage                string
-	ContainerdRegistryMirrors RegistryMirrorsFlags
+	ContainerRuntime                   string
+	ContainerdVersion                  string
+	InsecureRegistries                 string
+	RegistryMirrors                    string
+	RegistryCredentialsSecret          string
+	PauseImage                         string
+	ContainerdRegistryMirrors          RegistryMirrorsFlags
+	DeviceOwnershipFromSecurityContext bool
 }
 
 type DockerCfgJSON struct {
@@ -98,6 +99,7 @@ func BuildConfig(opts Opts) (Config, error) {
 		withRegistryMirrors(opts.ContainerdRegistryMirrors),
 		withSandboxImage(opts.PauseImage),
 		withContainerdVersion(opts.ContainerdVersion),
+		withDeviceOwnershipFromSecurityContext(opts.DeviceOwnershipFromSecurityContext),
 	), nil
 }
 

--- a/pkg/containerruntime/containerd.go
+++ b/pkg/containerruntime/containerd.go
@@ -23,11 +23,12 @@ import (
 )
 
 type Containerd struct {
-	insecureRegistries  []string
-	registryMirrors     map[string][]string
-	sandboxImage        string
-	registryCredentials map[string]AuthConfig
-	version             string
+	insecureRegistries                 []string
+	registryMirrors                    map[string][]string
+	sandboxImage                       string
+	registryCredentials                map[string]AuthConfig
+	version                            string
+	deviceOwnershipFromSecurityContext bool
 }
 
 func (eng *Containerd) ConfigFileName() string {
@@ -63,9 +64,10 @@ type containerdMetrics struct {
 }
 
 type containerdCRIPlugin struct {
-	Containerd   *containerdCRISettings `toml:"containerd"`
-	Registry     *containerdCRIRegistry `toml:"registry"`
-	SandboxImage string                 `toml:"sandbox_image,omitempty"`
+	Containerd                         *containerdCRISettings `toml:"containerd"`
+	Registry                           *containerdCRIRegistry `toml:"registry"`
+	SandboxImage                       string                 `toml:"sandbox_image,omitempty"`
+	DeviceOwnershipFromSecurityContext bool                   `toml:"device_ownership_from_security_context"`
 }
 
 type containerdCRISettings struct {
@@ -101,7 +103,8 @@ type containerdRegistryTLSConfig struct {
 
 func (eng *Containerd) Config() (string, error) {
 	criPlugin := containerdCRIPlugin{
-		SandboxImage: eng.sandboxImage,
+		SandboxImage:                       eng.sandboxImage,
+		DeviceOwnershipFromSecurityContext: eng.deviceOwnershipFromSecurityContext,
 		Containerd: &containerdCRISettings{
 			Runtimes: map[string]containerdCRIRuntime{
 				"runc": {

--- a/pkg/containerruntime/containerruntime.go
+++ b/pkg/containerruntime/containerruntime.go
@@ -55,6 +55,12 @@ func withContainerdVersion(version string) Opt {
 	}
 }
 
+func withDeviceOwnershipFromSecurityContext(deviceOwnershipFromSecurityContext bool) Opt {
+	return func(cfg *Config) {
+		cfg.DeviceOwnershipFromSecurityContext = deviceOwnershipFromSecurityContext
+	}
+}
+
 func get(_ string, opts ...Opt) Config {
 	cfg := Config{}
 	cfg.Containerd = &Containerd{}
@@ -67,14 +73,15 @@ func get(_ string, opts ...Opt) Config {
 }
 
 type Config struct {
-	Containerd           *Containerd           `json:",omitempty"`
-	InsecureRegistries   []string              `json:",omitempty"`
-	RegistryMirrors      map[string][]string   `json:",omitempty"`
-	RegistryCredentials  map[string]AuthConfig `json:",omitempty"`
-	SandboxImage         string                `json:",omitempty"`
-	ContainerLogMaxFiles string                `json:",omitempty"`
-	ContainerLogMaxSize  string                `json:",omitempty"`
-	ContainerdVersion    string                `json:",omitempty"`
+	Containerd                         *Containerd           `json:",omitempty"`
+	InsecureRegistries                 []string              `json:",omitempty"`
+	RegistryMirrors                    map[string][]string   `json:",omitempty"`
+	RegistryCredentials                map[string]AuthConfig `json:",omitempty"`
+	SandboxImage                       string                `json:",omitempty"`
+	ContainerLogMaxFiles               string                `json:",omitempty"`
+	ContainerLogMaxSize                string                `json:",omitempty"`
+	ContainerdVersion                  string                `json:",omitempty"`
+	DeviceOwnershipFromSecurityContext bool                  `json:",omitempty"`
 }
 
 // AuthConfig is a COPY of github.com/containerd/containerd/pkg/cri/config.AuthConfig.
@@ -98,11 +105,12 @@ func (cfg Config) String() string {
 
 func (cfg Config) Engine() Engine {
 	containerd := &Containerd{
-		insecureRegistries:  cfg.InsecureRegistries,
-		registryMirrors:     cfg.RegistryMirrors,
-		sandboxImage:        cfg.SandboxImage,
-		registryCredentials: cfg.RegistryCredentials,
-		version:             cfg.ContainerdVersion,
+		insecureRegistries:                 cfg.InsecureRegistries,
+		registryMirrors:                    cfg.RegistryMirrors,
+		sandboxImage:                       cfg.SandboxImage,
+		registryCredentials:                cfg.RegistryCredentials,
+		version:                            cfg.ContainerdVersion,
+		deviceOwnershipFromSecurityContext: cfg.DeviceOwnershipFromSecurityContext,
 	}
 	return containerd
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr adds a flag to configure the setting in containerd configuration whether non-root users are allowed to use devices on the node. ref: https://github.com/kubermatic/kubermatic/issues/14352

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
A flag called `device-ownership-from-security-context` was introduced to set containerd option to allow non-root user device usage on a node.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
