### PR TITLE
fix cloud-init bug on Hetzner that breaks networking after unattended upgrades 

### DIFF
--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -75,6 +75,19 @@ spec:
         sudo update-ca-certificates
         {{- end }}
 
+      configureHetznerNetplanOverlay: |-
+        # Overlay YAML so systemd-generator always finds a file
+        cat >/etc/netplan/99-hetzner-fallback-default.yaml <<'EOF'
+        network:
+          version: 2
+          renderer: networkd
+          ethernets:
+            eth0:
+              set-name: eth0
+              dhcp4: true
+              dhcp6: true
+        EOF
+
     files:
       - path: /opt/bin/supervise.sh
         permissions: 755
@@ -112,6 +125,16 @@ spec:
               {{- if eq .CloudProviderName "hetzner" }}
               sed -i '/\[Resolve\]/a FallbackDNS=1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com 2606:4700:4700::1111#cloudflare-dns.com 2606:4700:4700::1001#cloudflare-dns.com' /etc/systemd/resolved.conf
               systemctl restart systemd-resolved
+
+              # Remove default netplan config so we prevent dualstack and DHCP conflicts
+              rm /etc/netplan/50-cloud-init.yaml
+              echo "network: {config: disabled}" > /etc/cloud/cloud.cfg.d/99-custom-networking.cfg
+              # Write netplan fallback overlay file
+              {{- template "configureHetznerNetplanOverlay" }}
+
+              netplan generate
+              netplan apply
+              systemctl restart systemd-networkd
               {{- end }}
 
               export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug that causes Hetzner Ubuntu nodes to lose network connectivity after a reboot. 

This is happening because of the deletion of `/etc/netplan/50-cloud-init.yaml` during bootstrap. This initially doesn't break networking (since systemd will manage eth0), but it becomes a problem later. When a package upgrade happens, systemd will regenerate the network configuration (`netplan generate`). It then will wipe `/run/systemd/network` leaving no config to manage the interface. Once the network link flaps (happening in Hetzner), the interface will not be brought back up, basically isolating the node. 

My idea was to stop removing this default cloud-init netplan config, but I have seen that it will become a problem due to the fact that dual-stack networking stops working if we remove that line (xref: #200). 
There is also an option to disable the systemd generator, so it does not run netplan generate on boot, but I don't think this is the best solution to our problem because of the unintended consequences it could have.

The current PR resolves the issue by writing a fallback overlay with explicit DHCP config, running netplan generate and netplan apply, and restarting systemd-networkd.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #437 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
