### PR TITLE
fix: VCloud Flatcar with second nic, prevent second default route

### DIFF
--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -83,10 +83,10 @@ spec:
         subnetAddress() {
           local ip="$1"
           local mask="$2"
-        
+
           IFS=. read -r ip1 ip2 ip3 ip4 <<< "$ip"
           IFS=. read -r m1 m2 m3 m4 <<< "$mask"
-          
+
           # Compute subnet address with bitwise AND
           printf "%d.%d.%d.%d\n" \
           $((ip1 & m1)) \
@@ -128,7 +128,7 @@ spec:
               DNS2=$(query_ovf "vCloud_dns2_${PRIMARY_NIC}")
               echo "Gateway= ${GATEWAY}" >> /etc/systemd/network/0${i}-${INTERFACE}.network
               echo "DNS= ${DNS1} ${DNS2}" >> /etc/systemd/network/0${i}-${INTERFACE}.network
-        
+
             else
               NETWORK=$(subnetAddress "$IP" "$NETMASK")
               cat <<EOF >> /etc/systemd/network/0${i}-${INTERFACE}.network


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduced in #471 the option to add multiple nics for vmware cloud director and flatcar was added. After some further testing we realised, that the current osp created the network config in a way, that systemd-networkd also creates a default route for the second nic, which can result in random connection drops when the default route via the second nic is used and the network doesnt provide routing.

This pr fixes this, by removing the Gateway from the "[Network]" section and moving the route configration for the subnet to a seperate "[Route]" block.

**Which issue(s) this PR fixes**:


**What type of PR is this?**

/kind bug



**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
