### PR TITLE
Add support for Rocky Linux 10 in OSP

### DIFF
--- a/deploy/osps/default/osp-rockylinux.yaml
+++ b/deploy/osps/default/osp-rockylinux.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: kube-system
 spec:
   osName: "rockylinux"
-  osVersion: "9.6"
+  osVersion: "10.0"
   version: "v1.7.0"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
@@ -60,6 +60,19 @@ spec:
         EOF
         update-ca-trust
         {{- end }}
+
+      configureNetwork: |-
+        #cloud-config
+        DEFAULT_IFC_NAME=$(ip -o route get 1 | awk '{print $5}')
+        cat >/etc/cloud/cloud.cfg.d/99-network.cfg <<EOF
+        network:
+          version: 2
+          ethernets:
+            ${DEFAULT_IFC_NAME}:
+              dhcp4: true
+              dhcp6: true
+              accept-ra: true
+        EOF
 
     files:
       - path: /opt/bin/supervise.sh
@@ -106,8 +119,13 @@ spec:
                   cloud-init --file /etc/cloud/cloud.cfg.d/{{ .SecretName }}.cfg init
               fi
 
+              OS_MAJOR_VERSION=$(grep "^VERSION_ID=" /etc/os-release | cut -d '"' -f2 | cut -d '.' -f1)
+              if [ "$OS_MAJOR_VERSION" = "10" ]; then
+                  {{- template "configureNetwork" }}
+              fi
+
               {{- /* Prevent cloud-init from generating network files. */}}
-              {{- if (eq .CloudProviderName "hetzner") }}
+              {{- if (eq .CloudProviderName "hetzner") and "$OS_MAJOR_VERSION" = "9" }}
               echo "network: {config: disabled}" > /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
 
               # Let NetworkManager manage resolv.conf
@@ -179,7 +197,13 @@ spec:
         templates:
           containerRuntimeInstallation: |-
             yum install -y yum-utils
-            yum-config-manager --add-repo=https://download.docker.com/linux/rhel/docker-ce.repo
+            OS_MAJOR_VERSION=$(grep "^VERSION_ID=" /etc/os-release | cut -d '"' -f2 | cut -d '.' -f1)
+
+            if [ "$OS_MAJOR_VERSION" = "10" ]; then
+              yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+            else
+              yum-config-manager --add-repo=https://download.docker.com/linux/rhel/docker-ce.repo
+            fi
 
             yum install -y containerd.io-1.7* yum-plugin-versionlock
             yum versionlock add containerd.io
@@ -444,7 +468,13 @@ spec:
               #!/usr/bin/env bash
               set -euo pipefail
 
-              modprobe ip_tables
+              OS_MAJOR_VERSION=$(grep "^VERSION_ID=" /etc/os-release | cut -d '"' -f2 | cut -d '.' -f1)
+              if [ "$OS_MAJOR_VERSION" = "10" ]; then
+                modprobe nf_tables
+              else
+                modprobe ip_tables
+              fi
+
               modprobe ip_vs
               modprobe ip_vs_rr
               modprobe ip_vs_wrr
@@ -536,6 +566,26 @@ spec:
                 {{- end }}
                 ipvsadm
 
+              OS_MAJOR_VERSION=$(grep "^VERSION_ID=" /etc/os-release | cut -d '"' -f2 | cut -d '.' -f1)
+              if [ "$OS_MAJOR_VERSION" = "10" ]; then
+                yum install -y \
+                kernel-modules-extra-$(uname -r) \
+                nftables
+
+                sudo systemctl enable --now nftables
+              else
+                DEFAULT_IFC_NAME=$(ip -o route get 1  | grep -oP "dev \K\S+")
+                IFC_CFG_FILE=/etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+                # Enable IPv6 and DHCPv6 on the default interface
+                grep IPV6INIT $IFC_CFG_FILE && sed -i '/IPV6INIT*/c IPV6INIT=yes' $IFC_CFG_FILE || echo "IPV6INIT=yes" >> $IFC_CFG_FILE
+                grep DHCPV6C $IFC_CFG_FILE && sed -i '/DHCPV6C*/c DHCPV6C=yes' $IFC_CFG_FILE || echo "DHCPV6C=yes" >> $IFC_CFG_FILE
+                grep IPV6_AUTOCONF $IFC_CFG_FILE && sed -i '/IPV6_AUTOCONF*/c IPV6_AUTOCONF=yes' $IFC_CFG_FILE || echo "IPV6_AUTOCONF=yes" >> $IFC_CFG_FILE
+                # Restart NetworkManager to apply for IPv6 configs
+                systemctl restart NetworkManager
+                # Let NetworkManager apply the DHCPv6 configs
+                sleep 3
+              fi
+
               systemctl disable --now firewalld || true
 
               {{- /* iscsid service is required on Nutanix machines for CSI driver to attach volumes. */}}
@@ -546,17 +596,6 @@ spec:
               {{- template "containerRuntimeInstallation" }}
 
               {{- template "safeDownloadBinariesScript" }}
-
-              DEFAULT_IFC_NAME=$(ip -o route get 1  | grep -oP "dev \K\S+")
-              IFC_CFG_FILE=/etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
-              # Enable IPv6 and DHCPv6 on the default interface
-              grep IPV6INIT $IFC_CFG_FILE && sed -i '/IPV6INIT*/c IPV6INIT=yes' $IFC_CFG_FILE || echo "IPV6INIT=yes" >> $IFC_CFG_FILE
-              grep DHCPV6C $IFC_CFG_FILE && sed -i '/DHCPV6C*/c DHCPV6C=yes' $IFC_CFG_FILE || echo "DHCPV6C=yes" >> $IFC_CFG_FILE
-              grep IPV6_AUTOCONF $IFC_CFG_FILE && sed -i '/IPV6_AUTOCONF*/c IPV6_AUTOCONF=yes' $IFC_CFG_FILE || echo "IPV6_AUTOCONF=yes" >> $IFC_CFG_FILE
-              # Restart NetworkManager to apply for IPv6 configs
-              systemctl restart NetworkManager
-              # Let NetworkManager apply the DHCPv6 configs
-              sleep 3
 
               mkdir -p /etc/systemd/system/kubelet.service.d/
               # set kubelet nodeip environment variable


### PR DESCRIPTION
**What this PR does / why we need it**:
Added support for Rocky Linux 10 in OSP. This version introduces a few key changes:
- Docker has not yet released `yum` repository configurations for Rocky 10, so manual handling is required.
- The legacy `ifcfg` networking scripts are no longer supported.
- The `ip_tables` kernel module is not available, `nftables` is the default replacement.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #470 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for rocky linux 10
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
