### PR TITLE
chore: switch from drop-ins to drop_ins, fix: templating of DropIns

### DIFF
--- a/deploy/crd/operatingsystemmanager.k8c.io_operatingsystemconfigs.yaml
+++ b/deploy/crd/operatingsystemmanager.k8c.io_operatingsystemconfigs.yaml
@@ -136,7 +136,7 @@ spec:
                           description: Content is the unit's content.
                           type: string
                         dropIns:
-                          description: DropIns is a list of drop-ins for this unit.
+                          description: DropIns is a list of drop_ins for this unit.
                           items:
                             description: DropIn is a drop-in configuration for a systemd
                               unit.
@@ -314,7 +314,7 @@ spec:
                           description: Content is the unit's content.
                           type: string
                         dropIns:
-                          description: DropIns is a list of drop-ins for this unit.
+                          description: DropIns is a list of drop_ins for this unit.
                           items:
                             description: DropIn is a drop-in configuration for a systemd
                               unit.

--- a/deploy/crd/operatingsystemmanager.k8c.io_operatingsystemprofiles.yaml
+++ b/deploy/crd/operatingsystemmanager.k8c.io_operatingsystemprofiles.yaml
@@ -208,7 +208,7 @@ spec:
                           description: Content is the unit's content.
                           type: string
                         dropIns:
-                          description: DropIns is a list of drop-ins for this unit.
+                          description: DropIns is a list of drop_ins for this unit.
                           items:
                             description: DropIn is a drop-in configuration for a systemd
                               unit.
@@ -417,7 +417,7 @@ spec:
                           description: Content is the unit's content.
                           type: string
                         dropIns:
-                          description: DropIns is a list of drop-ins for this unit.
+                          description: DropIns is a list of drop_ins for this unit.
                           items:
                             description: DropIn is a drop-in configuration for a systemd
                               unit.

--- a/hack/kkp/operatingsystemmanager.k8c.io_customoperatingsystemprofiles.yaml
+++ b/hack/kkp/operatingsystemmanager.k8c.io_customoperatingsystemprofiles.yaml
@@ -201,7 +201,7 @@ spec:
                             description: Content is the unit's content.
                             type: string
                           dropIns:
-                            description: DropIns is a list of drop-ins for this unit.
+                            description: DropIns is a list of drop_ins for this unit.
                             items:
                               description: DropIn is a drop-in configuration for a systemd unit.
                               properties:
@@ -387,7 +387,7 @@ spec:
                             description: Content is the unit's content.
                             type: string
                           dropIns:
-                            description: DropIns is a list of drop-ins for this unit.
+                            description: DropIns is a list of drop_ins for this unit.
                             items:
                               description: DropIn is a drop-in configuration for a systemd unit.
                               properties:

--- a/pkg/crd/osm/v1alpha1/common_types.go
+++ b/pkg/crd/osm/v1alpha1/common_types.go
@@ -96,7 +96,7 @@ type Unit struct {
 	Mask *bool `json:"mask,omitempty"`
 	// Content is the unit's content.
 	Content *string `json:"content,omitempty"`
-	// DropIns is a list of drop-ins for this unit.
+	// DropIns is a list of drop_ins for this unit.
 	DropIns []DropIn `json:"dropIns,omitempty"`
 }
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -253,13 +253,13 @@ coreos:
 	command: start
 	{{- end }}
     mask: {{or $unit.Mask false}}
-{{ if $unit.Content }}
+{{ with $unit.Content }}
     content: |
-{{ $unit.Content | indent 6 }}
+{{ . | indent 6 }}
 {{- end }}
-{{ if $unit.Content }}
-    drop-ins:
-{{- range $_, $dropIn := $unit.DropIns }}
+{{ with $unit.DropIns }}
+    drop_ins:
+{{- range $_, $dropIn := . }}
       - name: "{{ $dropIn.Name }}"
         content: |
 {{ $dropIn.Content | indent 10 }}
@@ -341,13 +341,13 @@ systemd:
   - name: {{ $unit.Name }}
     enabled: {{or $unit.Enable false}}
     mask: {{or $unit.Mask false}}
-{{ if $unit.Content }}
+{{ with $unit.Content }}
     contents: |
-{{ $unit.Content | indent 6 }}
+{{ . | indent 6 }}
 {{- end }}
-{{ if $unit.Content }}
+{{ with $unit.DropIns }}
     dropins:
-{{- range $_, $dropIn := $unit.DropIns }}
+{{- range $_, $dropIn := . }}
       - name: {{ $dropIn.Name }}
         contents: |
 {{ $dropIn.Content | indent 10 }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes originally from https://github.com/kubermatic/operating-system-manager/pull/475

- CoreOS Cloud Init is not reading the `drop-ins` sections in cloud-config.yml since Flatcar 3975.2.0, so we switch to `drop_ins`.
- CoreOS Cloud Init is not correctly templating the drop-ins sections because of a wrong condition (`{{ if $unit.Content }}` instead of `{{ if $unit.DropIns }}` or `{{ with $unit.DropIns }}`)

**Which issue(s) this PR fixes**:

Fixes [#1567](https://github.com/flatcar/Flatcar/issues/1567)

**What type of PR is this?**

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
fix: templating of DropIns
```

**Documentation**:

```
NONE
```
