### PR TITLE
replace eth0 interface with fallback netplan match on Hetzner Ubuntu nodes 

### DIFF
--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -77,13 +77,15 @@ spec:
 
       configureHetznerNetplanOverlay: |-
         # Overlay YAML so systemd-generator always finds a file
+        install -m 600 -o root -g root /dev/null /etc/netplan/99-hetzner-fallback-default.yaml
         cat >/etc/netplan/99-hetzner-fallback-default.yaml <<'EOF'
         network:
           version: 2
           renderer: networkd
           ethernets:
-            eth0:
-              set-name: eth0
+            fallback:
+              match:
+                name: "e*"
               dhcp4: true
               dhcp6: true
         EOF
@@ -127,7 +129,7 @@ spec:
               systemctl restart systemd-resolved
 
               # Remove default netplan config so we prevent dualstack and DHCP conflicts
-              rm /etc/netplan/50-cloud-init.yaml
+              rm /etc/netplan/50-cloud-init.yaml || true
               echo "network: {config: disabled}" > /etc/cloud/cloud.cfg.d/99-custom-networking.cfg
               # Write netplan fallback overlay file
               {{- template "configureHetznerNetplanOverlay" }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue with netplan fallback config in Hetzner OSPs. We will keep the **original approach** introduced in this PR: https://github.com/kubermatic/operating-system-manager/pull/502, but only change how the OSP netplan overlay configures the eth0 interface. Using `set-name` without proper match blocks leads to invalid netplan configuration and systemd-networkd errors.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
References https://github.com/kubermatic/operating-system-manager/issues/437

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
