### PR TITLE
Fix IP assignment issues on Hetzner

### DIFF
--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -75,21 +75,6 @@ spec:
         sudo update-ca-certificates
         {{- end }}
 
-      configureHetznerNetplanOverlay: |-
-        # Overlay YAML so systemd-generator always finds a file
-        install -m 600 -o root -g root /dev/null /etc/netplan/99-hetzner-fallback-default.yaml
-        cat >/etc/netplan/99-hetzner-fallback-default.yaml <<'EOF'
-        network:
-          version: 2
-          renderer: networkd
-          ethernets:
-            fallback:
-              match:
-                name: "e*"
-              dhcp4: true
-              dhcp6: true
-        EOF
-
     files:
       - path: /opt/bin/supervise.sh
         permissions: 755
@@ -128,15 +113,8 @@ spec:
               sed -i '/\[Resolve\]/a FallbackDNS=1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com 2606:4700:4700::1111#cloudflare-dns.com 2606:4700:4700::1001#cloudflare-dns.com' /etc/systemd/resolved.conf
               systemctl restart systemd-resolved
 
-              # Remove default netplan config so we prevent dualstack and DHCP conflicts
-              rm /etc/netplan/50-cloud-init.yaml || true
-              echo "network: {config: disabled}" > /etc/cloud/cloud.cfg.d/99-custom-networking.cfg
-              # Write netplan fallback overlay file
-              {{- template "configureHetznerNetplanOverlay" }}
-
-              netplan generate
-              netplan apply
-              systemctl restart systemd-networkd
+              # Backup default netplan config
+              cp /etc/netplan/50-cloud-init.yaml /etc/netplan-50-cloud-init.yaml.bak
               {{- end }}
 
               export DEBIAN_FRONTEND=noninteractive
@@ -169,6 +147,14 @@ spec:
               {{- if eq .CloudProviderName "digitalocean" }}
               netplan generate
               netplan apply
+              {{- end }}
+
+              {{- if eq .CloudProviderName "hetzner" }}
+              # Restore default netplan config
+              cp /etc/netplan-50-cloud-init.yaml.bak /etc/netplan/50-cloud-init.yaml
+              systemctl daemon-reload
+              netplan apply
+              systemctl restart systemd-networkd
               {{- end }}
 
               systemctl daemon-reload


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix issues with IP allocation on Hetzner. Previously, we were disabling netplan in order to get around the invalid/empty netplan configuration that is generated when running cloud-init for the second time. Although this empty configuration leads to issues when the machines are rebooted or after an apt upgrade.

To circumvent this, we backup the netplan configuration that is generated initially for the machine and re-apply it using `netplan apply` after the second run for cloud-init has completed.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #517, #437, https://github.com/kubermatic/machine-controller/issues/1587

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a bug where Hetzner machines were losing IPs on reboots
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
