### PR TITLE
Fix typo in the comment of default OSPs

### DIFF
--- a/deploy/osps/default/osp-amzn2.yaml
+++ b/deploy/osps/default/osp-amzn2.yaml
@@ -279,7 +279,7 @@ spec:
         sha256sum -c "$kube_sum_file"
 
         for bin in kubelet kubeadm kubectl; do
-            {{- /* link kube binaries from verioned dir to $opt_bin */}}
+            {{- /* link kube binaries from versioned dir to $opt_bin */}}
             ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
         done
 

--- a/deploy/osps/default/osp-flatcar-cloud-init.yaml
+++ b/deploy/osps/default/osp-flatcar-cloud-init.yaml
@@ -166,7 +166,7 @@ spec:
         sha256sum -c "$kube_sum_file"
 
         for bin in kubelet kubeadm kubectl; do
-            {{- /* link kube binaries from verioned dir to $opt_bin */}}
+            {{- /* link kube binaries from versioned dir to $opt_bin */}}
             ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
         done
 

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -375,7 +375,7 @@ spec:
         sha256sum -c "$kube_sum_file"
 
         for bin in kubelet kubeadm kubectl; do
-            {{- /* link kube binaries from verioned dir to $opt_bin */}}
+            {{- /* link kube binaries from versioned dir to $opt_bin */}}
             ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
         done
 

--- a/deploy/osps/default/osp-rhel.yaml
+++ b/deploy/osps/default/osp-rhel.yaml
@@ -295,7 +295,7 @@ spec:
         sha256sum -c "$kube_sum_file"
 
         for bin in kubelet kubeadm kubectl; do
-            {{- /* link kube binaries from verioned dir to $opt_bin */}}
+            {{- /* link kube binaries from versioned dir to $opt_bin */}}
             ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
         done
 

--- a/deploy/osps/default/osp-rockylinux.yaml
+++ b/deploy/osps/default/osp-rockylinux.yaml
@@ -299,7 +299,7 @@ spec:
         sha256sum -c "$kube_sum_file"
 
         for bin in kubelet kubeadm kubectl; do
-            {{- /* link kube binaries from verioned dir to $opt_bin */}}
+            {{- /* link kube binaries from versioned dir to $opt_bin */}}
             ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
         done
 

--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -344,7 +344,7 @@ spec:
         sha256sum -c "$kube_sum_file"
 
         for bin in kubelet kubeadm kubectl; do
-            {{- /* link kube binaries from verioned dir to $opt_bin */}}
+            {{- /* link kube binaries from versioned dir to $opt_bin */}}
             ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
         done
 

--- a/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
+++ b/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
@@ -275,7 +275,7 @@ spec:
         sha256sum -c "$kube_sum_file"
 
         for bin in kubelet kubeadm kubectl; do
-            {{- /* link kube binaries from verioned dir to $opt_bin */}}
+            {{- /* link kube binaries from versioned dir to $opt_bin */}}
             ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
         done
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to fix typo `verioned` -> `versioned` in the comment of default OSPs

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
