### PR TITLE
Move configureHostCABundle template to the provisioning phase

### DIFF
--- a/deploy/osps/default/osp-amzn2.yaml
+++ b/deploy/osps/default/osp-amzn2.yaml
@@ -46,14 +46,6 @@ spec:
 
         source /etc/environment
 
-      configureHostCABundle: |-
-        {{- if .HostCACert }}
-        cat <<EOF | tee /usr/local/share/ca-certificates/custom.crt
-        {{ .HostCACert }}
-        EOF
-        update-ca-certificates
-        {{- end }}
-
     files:
       - path: /opt/bin/supervise.sh
         permissions: 755
@@ -84,7 +76,6 @@ spec:
 
               {{- /* Configure proxy as the first step to ensure that all the phases of provisioning respect the proxy environment. */}}
               {{- template "configureProxyScript" }}
-              {{- template "configureHostCABundle" }}
 
               yum install -y curl jq
 
@@ -282,6 +273,14 @@ spec:
             {{- /* link kube binaries from versioned dir to $opt_bin */}}
             ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
         done
+
+      configureHostCABundle: |-
+        {{- with .HostCACert }}
+        cat <<EOF | tee /usr/local/share/ca-certificates/custom.crt
+        {{ . }}
+        EOF
+        update-ca-certificates
+        {{- end }}
 
     files:
       - path: /opt/bin/health-monitor.sh
@@ -488,6 +487,8 @@ spec:
               {{- /* As we added some modules and don't want to reboot, restart the service */}}
               systemctl restart systemd-modules-load.service
               sysctl --system
+
+              {{- template "configureHostCABundle" }}
 
               yum install -y \
                 device-mapper-persistent-data \

--- a/deploy/osps/default/osp-flatcar-cloud-init.yaml
+++ b/deploy/osps/default/osp-flatcar-cloud-init.yaml
@@ -48,9 +48,9 @@ spec:
         source /etc/environment
 
       configureHostCABundle: |-
-        {{- if .HostCACert }}
+        {{- with .HostCACert }}
         cat <<EOF | tee /etc/ssl/certs/custom.pem
-        {{ .HostCACert }}
+        {{ . }}
         EOF
         update-ca-certificates
         {{- end }}

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -143,14 +143,6 @@ spec:
 
         done
 
-      configureHostCABundle: |-
-        {{- if .HostCACert }}
-        cat <<EOF | tee /etc/ssl/certs/custom.pem
-        {{ .HostCACert }}
-        EOF
-        update-ca-certificates
-        {{- end }}
-
     units:
       - name: bootstrap.service
         enable: true
@@ -199,7 +191,6 @@ spec:
 
               {{- /* Configure proxy as the first step to ensure that all the phases of provisioning respect the proxy environment. */}}
               {{- template "configureProxyScript" }}
-              {{- template "configureHostCABundle" }}
 
               curl -s -k -v --header 'Authorization: Bearer {{ .Token }}'	{{ .ServerURL }}/api/v1/namespaces/cloud-init-settings/secrets/{{ .SecretName }} | jq '.data["cloud-config"]' -r| base64 -d > /usr/share/oem/config.ign
 
@@ -378,6 +369,14 @@ spec:
             {{- /* link kube binaries from versioned dir to $opt_bin */}}
             ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
         done
+
+      configureHostCABundle: |-
+        {{- with .HostCACert }}
+        cat <<EOF | tee /etc/ssl/certs/custom.pem
+        {{ . }}
+        EOF
+        update-ca-certificates
+        {{- end }}
 
     units:
       - name: setup.service
@@ -639,6 +638,7 @@ spec:
             data: |
               [Network]
               IPv6AcceptRA=true
+
       - path: /opt/bin/setup
         permissions: 755
         content:
@@ -646,6 +646,8 @@ spec:
             data: |
               #!/bin/bash
               set -xeuo pipefail
+
+              {{- template "configureHostCABundle" }}
 
               {{- if not .FlatcarConfig.DisableAutoUpdate }}
               cat << EOF | tee /etc/polkit-1/rules.d/60-noreboot_norestart.rules

--- a/deploy/osps/default/osp-rhel.yaml
+++ b/deploy/osps/default/osp-rhel.yaml
@@ -50,14 +50,6 @@ spec:
 
         source /etc/environment
 
-      configureHostCABundle: |-
-        {{- if .HostCACert }}
-        cat <<EOF | tee /etc/pki/ca-trust/source/whitelist/custom.crt
-        {{ .HostCACert }}
-        EOF
-        update-ca-trust
-        {{- end }}
-
     files:
       - path: /opt/bin/supervise.sh
         permissions: 755
@@ -88,7 +80,6 @@ spec:
 
               {{- /* Configure proxy as the first step to ensure that all the phases of provisioning respect the proxy environment. */}}
               {{- template "configureProxyScript" }}
-              {{- template "configureHostCABundle" }}
 
               yum install -y curl jq
 
@@ -299,6 +290,14 @@ spec:
             ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
         done
 
+      configureHostCABundle: |-
+        {{- with .HostCACert }}
+        cat <<EOF | tee /etc/pki/ca-trust/source/whitelist/custom.crt
+        {{ . }}
+        EOF
+        update-ca-trust
+        {{- end }}
+
     files:
       - path: /opt/bin/health-monitor.sh
         permissions: 755
@@ -501,6 +500,8 @@ spec:
               set -xeuo pipefail
 
               setenforce 0 || true
+
+              {{- template "configureHostCABundle" }}
 
               {{- /* As we added some modules and don't want to reboot, restart the service */}}
               systemctl restart systemd-modules-load.service

--- a/deploy/osps/default/osp-rockylinux.yaml
+++ b/deploy/osps/default/osp-rockylinux.yaml
@@ -53,14 +53,6 @@ spec:
 
         source /etc/environment
 
-      configureHostCABundle: |-
-        {{- if .HostCACert }}
-        cat <<EOF | tee /etc/pki/ca-trust/source/anchors/custom.crt
-        {{ .HostCACert }}
-        EOF
-        update-ca-trust
-        {{- end }}
-
     files:
       - path: /opt/bin/supervise.sh
         permissions: 755
@@ -91,7 +83,6 @@ spec:
 
               {{- /* Configure proxy as the first step to ensure that all the phases of provisioning respect the proxy environment. */}}
               {{- template "configureProxyScript" }}
-              {{- template "configureHostCABundle" }}
 
               yum install -y curl jq
 
@@ -303,6 +294,14 @@ spec:
             ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
         done
 
+      configureHostCABundle: |-
+        {{- with .HostCACert }}
+        cat <<EOF | tee /etc/pki/ca-trust/source/anchors/custom.crt
+        {{ . }}
+        EOF
+        update-ca-trust
+        {{- end }}
+
     files:
       - path: /opt/bin/health-monitor.sh
         permissions: 755
@@ -505,6 +504,8 @@ spec:
               set -xeuo pipefail
 
               setenforce 0 || true
+
+              {{- template "configureHostCABundle" }}
 
               {{- /* As we added some modules and don't want to reboot, restart the service */}}
               systemctl restart systemd-modules-load.service

--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -67,14 +67,6 @@ spec:
 
         source /etc/environment
 
-      configureHostCABundle: |-
-        {{- if .HostCACert }}
-        cat <<EOF | sudo tee /usr/local/share/ca-certificates/custom.crt
-        {{ .HostCACert }}
-        EOF
-        sudo update-ca-certificates
-        {{- end }}
-
     files:
       - path: /opt/bin/supervise.sh
         permissions: 755
@@ -105,7 +97,6 @@ spec:
 
               {{- /* Configure proxy as the first step to ensure that all the phases of provisioning respect the proxy environment. */}}
               {{- template "configureProxyScript" }}
-              {{- template "configureHostCABundle" }}
 
               {{- /* Starting with Ubuntu 24.04, there is an issue with DNS resolution that leaves machines without connectivity consistently. We even observed this issue on machines
               where the netplan wasn't executed in the second cloud-init run. To fix this we are adding Cloudfare as fallback for DNS resolution */}}
@@ -348,6 +339,14 @@ spec:
             ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
         done
 
+      configureHostCABundle: |-
+        {{- with .HostCACert }}
+        cat <<EOF | sudo tee /usr/local/share/ca-certificates/custom.crt
+        {{ . }}
+        EOF
+        sudo update-ca-certificates
+        {{- end }}
+
     files:
       - path: /opt/bin/health-monitor.sh
         permissions: 755
@@ -552,6 +551,8 @@ spec:
                 machine_name=$(cat /etc/machine-name)
                 hostnamectl set-hostname ${machine_name}
               fi
+
+              {{- template "configureHostCABundle" }}
 
               apt-get update
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes the issue when provided CABundle is too big, which breaks the limits of user-data.

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Move configureHostCABundle template to the provisioning phase
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
