### PR TITLE
Update base image for operating-system-manager container image to apline:3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /go/src/k8c.io/operating-system-manager
 COPY . .
 RUN make all
 
-FROM alpine:3.19
+FROM alpine:3.23
 
 RUN apk add --no-cache ca-certificates cdrkit
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a maintenance PR to update base image for operating-system-manager container image to alpine:3.23. Security support for Alpine Linux v3.19 officially ended on November 1, 2025. Hence bumping with current stable release v3.23.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update base image for operating-system-manager container image to apline:3.23
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
