### PR TITLE
Update osm to use EndpointSlices for API server discovery

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -111,12 +111,6 @@ linters:
       - std-error-handling
       - common-false-positives
       - legacy
-    rules:
-      # TODO: Should be fixed via https://github.com/kubermatic/operating-system-manager/issues/513
-      - path: (.+)\.go$
-        text: 'SA1019: corev1.Endpoints is deprecated: This API is deprecated in v1.33+.'
-      - path: (.+)\.go$
-        text: 'SA1019: corev1.EndpointSubset is deprecated: This API is deprecated in v1.33+.'
     paths:
       - zz_generated.*.go
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates osm to use the EndpointSlices API from the deprecated Kubernetes Endpoints API. The Endpoints API is deprecated in Kubernetes v1.33+. The fallback mechanism now uses EndpointSlices to discover the API server address instead of Endpoints in OSM.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/operating-system-manager/issues/513

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
