### PR TITLE
Properly check for updates to OSC/Secrets in Reconcile

### DIFF
--- a/pkg/controllers/osc/osc_controller.go
+++ b/pkg/controllers/osc/osc_controller.go
@@ -585,7 +585,7 @@ func validateMachineDeployment(md *clusterv1alpha1.MachineDeployment, osp *osmv1
 		}
 	}
 
-	// Ensure that OSP supports the operating system
+	// Ensure that OSP supports the cloud provider
 	if !supportedCloudProvider {
 		return fmt.Errorf("OperatingSystemProfile %q does not support cloud provider %q", osp.Name, providerConfig.CloudProvider)
 	}

--- a/pkg/controllers/osc/osc_controller.go
+++ b/pkg/controllers/osc/osc_controller.go
@@ -177,20 +177,25 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrlruntime.Request) (re
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, md *clusterv1alpha1.MachineDeployment) error {
-	if err := r.checkOSP(ctx, md); err != nil {
+	osp, err := r.fetchOSP(ctx, md)
+	if err != nil {
+		return fmt.Errorf("failed to fetch OperatingSystemProfile: %w", err)
+	}
+
+	if err := r.checkOSP(md, osp); err != nil {
 		return fmt.Errorf("failed to validate referenced OSP: %w", err)
 	}
 
 	// Check if OSC and secret need to be rotated
-	if err := r.handleOSCAndSecretsRotation(ctx, md); err != nil {
+	if err := r.handleOSCAndSecretsRotation(ctx, md, osp); err != nil {
 		return fmt.Errorf("failed to perform rotation for OSC and secrets: %w", err)
 	}
 
-	if err := r.reconcileOperatingSystemConfigs(ctx, md); err != nil {
+	if err := r.reconcileOperatingSystemConfigs(ctx, md, osp); err != nil {
 		return fmt.Errorf("failed to reconcile operating system config: %w", err)
 	}
 
-	if err := r.reconcileSecrets(ctx, md); err != nil {
+	if err := r.reconcileSecrets(ctx, md, osp); err != nil {
 		return fmt.Errorf("failed to reconcile secrets: %w", err)
 	}
 
@@ -209,7 +214,7 @@ func (r *Reconciler) fetchOSP(ctx context.Context, md *clusterv1alpha1.MachineDe
 	osp := &osmv1alpha1.OperatingSystemProfile{}
 	if err := r.Get(ctx, types.NamespacedName{Name: ospName, Namespace: ospNamespace}, osp); err != nil {
 		if kerrors.IsNotFound(err) {
-			return nil,fmt.Errorf("OperatingSystemProfile %q not found", ospName)
+			return nil, fmt.Errorf("OperatingSystemProfile %q not found", ospName)
 		}
 
 		return nil, fmt.Errorf("failed to get OperatingSystemProfile %q from namespace %q: %w", ospName, ospNamespace, err)
@@ -218,7 +223,7 @@ func (r *Reconciler) fetchOSP(ctx context.Context, md *clusterv1alpha1.MachineDe
 	return osp, nil
 }
 
-func (r *Reconciler) reconcileOperatingSystemConfigs(ctx context.Context, md *clusterv1alpha1.MachineDeployment) error {
+func (r *Reconciler) reconcileOperatingSystemConfigs(ctx context.Context, md *clusterv1alpha1.MachineDeployment, osp *osmv1alpha1.OperatingSystemProfile) error {
 	machineDeploymentKey := fmt.Sprintf("%s-%s", md.Namespace, md.Name)
 	// machineDeploymentKey must be no more than 63 characters else it'll fail to create bootstrap token.
 	if len(machineDeploymentKey) >= 63 {
@@ -237,11 +242,6 @@ func (r *Reconciler) reconcileOperatingSystemConfigs(ctx context.Context, md *cl
 	if err := r.Get(ctx, types.NamespacedName{Name: oscName, Namespace: r.namespace}, osc); err == nil {
 		// Early return since the object already exists
 		return nil
-	}
-
-	osp, err := r.fetchOSP(ctx, md)
-	if err != nil {
-		return err
 	}
 
 	provisioner, err := generator.GetProvisioningUtility(osp.Spec.OSName, *md)
@@ -303,7 +303,7 @@ func (r *Reconciler) reconcileOperatingSystemConfigs(ctx context.Context, md *cl
 		return err
 	}
 
-	osc.Annotations = addMachineDeploymentRevision(revision, mdhash, osp.Spec.Version, osc.Annotations)
+	osc.Annotations = oscRotationAnnotations(revision, mdhash, osp.Spec.Version, osc.Annotations)
 	osc.Spec.ProvisioningUtility = osp.Spec.ProvisioningUtility
 
 	// Defaults to cloud-init although we should never hit this condition i.e ProvisioningUtility in OSP to be empty.
@@ -319,13 +319,9 @@ func (r *Reconciler) reconcileOperatingSystemConfigs(ctx context.Context, md *cl
 	return nil
 }
 
-func (r *Reconciler) reconcileSecrets(ctx context.Context, md *clusterv1alpha1.MachineDeployment) error {
+func (r *Reconciler) reconcileSecrets(ctx context.Context, md *clusterv1alpha1.MachineDeployment, osp *osmv1alpha1.OperatingSystemProfile) error {
 	oscName := fmt.Sprintf(resources.OperatingSystemConfigNamePattern, md.Name, md.Namespace)
 	osc := &osmv1alpha1.OperatingSystemConfig{}
-	osp, err := r.fetchOSP(ctx, md)
-	if err != nil {
-		return err
-	}
 
 	if err := r.Get(ctx, types.NamespacedName{Namespace: r.namespace, Name: oscName}, osc); err != nil {
 		return fmt.Errorf("failed to get OperatingSystemConfigs %q from namespace %q: %w", oscName, r.namespace, err)
@@ -367,7 +363,7 @@ func (r *Reconciler) ensureCloudConfigSecret(ctx context.Context, config osmv1al
 		return err
 	}
 
-	secret.Annotations = addMachineDeploymentRevision(revision, mdhash, ospVersion, secret.Annotations) // Ashley: we do not check the hash here as OSC also regenerates Secrets
+	secret.Annotations = oscRotationAnnotations(revision, mdhash, ospVersion, secret.Annotations) // we do not check the hash here as OSC also regenerates Secrets
 
 	// Create resource in cluster
 	if err := r.workerClient.Create(ctx, secret); err != nil {
@@ -458,7 +454,7 @@ func (r *Reconciler) deleteGeneratedSecrets(ctx context.Context, md *clusterv1al
 	return nil
 }
 
-func (r *Reconciler) handleOSCAndSecretsRotation(ctx context.Context, md *clusterv1alpha1.MachineDeployment) error {
+func (r *Reconciler) handleOSCAndSecretsRotation(ctx context.Context, md *clusterv1alpha1.MachineDeployment, osp *osmv1alpha1.OperatingSystemProfile) error {
 	oscName := fmt.Sprintf(resources.OperatingSystemConfigNamePattern, md.Name, md.Namespace)
 	osc := &osmv1alpha1.OperatingSystemConfig{}
 	if err := r.Get(ctx, types.NamespacedName{Name: oscName, Namespace: r.namespace}, osc); err != nil {
@@ -471,12 +467,6 @@ func (r *Reconciler) handleOSCAndSecretsRotation(ctx context.Context, md *cluste
 
 	// OSC already exists, we need to check if the template in machine deployment was updated. If it's updated then we need to rotate
 	// the OSC and secrets.
-	
-	// first verify OSC vs OSP version
-	osp, err := r.fetchOSP(ctx, md)
-	if err != nil {
-		return err
-	}
 
 	// now also check that the MD annotations have not changed as those can generate some differences in the output OSC
 	mdhash, err := r.calculateAnnotationsHash(md.Annotations)
@@ -514,8 +504,8 @@ func (r *Reconciler) calculateAnnotationsHash(annotations map[string]string) (st
 	return mdhash, nil
 }
 
-func (r *Reconciler) checkOSP(ctx context.Context, md *clusterv1alpha1.MachineDeployment) error {
-	err := validateMachineDeployment(ctx, md, r.Client, r.namespace)
+func (r *Reconciler) checkOSP(md *clusterv1alpha1.MachineDeployment, osp *osmv1alpha1.OperatingSystemProfile) error {
+	err := validateMachineDeployment(md, osp)
 	if err != nil {
 		r.recorder.Event(md, corev1.EventTypeWarning, "OperatingSystemProfileError", err.Error())
 	}
@@ -561,7 +551,7 @@ func filterMachineDeploymentPredicate() predicate.Predicate {
 	})
 }
 
-func addMachineDeploymentRevision(revision, mdhash, ospversion string, annotations map[string]string) map[string]string {
+func oscRotationAnnotations(revision, mdhash, ospversion string, annotations map[string]string) map[string]string {
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
@@ -569,36 +559,15 @@ func addMachineDeploymentRevision(revision, mdhash, ospversion string, annotatio
 	annotations[mcbootstrap.MachineDeploymentRevision] = revision
 	annotations[OperatingSystemConfigMDHash] = mdhash
 	annotations[OperatingSystemConfigVersionAnnotation] = ospversion
+
 	return annotations
 }
 
-func validateMachineDeployment(ctx context.Context, md *clusterv1alpha1.MachineDeployment, client ctrlruntimeclient.Client, namespace string) error {
-	ospName := md.Annotations[resources.MachineDeploymentOSPAnnotation]
-	// Ignoring request since no OperatingSystemProfile found
-	if len(ospName) == 0 {
-		// Returning here as MD without this annotation shouldn't be validated
-		return nil
-	}
-
-	ospNamespace := md.Annotations[resources.MachineDeploymentOSPNamespaceAnnotation]
-	if len(ospNamespace) == 0 {
-		ospNamespace = namespace
-	}
-
-	osp := &osmv1alpha1.OperatingSystemProfile{}
-	err := client.Get(ctx, types.NamespacedName{Name: ospName, Namespace: ospNamespace}, osp)
-	if err != nil {
-		if kerrors.IsNotFound(err) {
-			return fmt.Errorf("OperatingSystemProfile %q not found", ospName)
-		}
-
-		return fmt.Errorf("failed to fetch OperatingSystemProfile %q: %w", ospName, err)
-	}
-
+func validateMachineDeployment(md *clusterv1alpha1.MachineDeployment, osp *osmv1alpha1.OperatingSystemProfile) error {
 	// Get providerConfig from machineDeployment
 	providerConfig := providerconfig.Config{}
-	err = json.Unmarshal(md.Spec.Template.Spec.ProviderSpec.Value.Raw, &providerConfig)
-	if err != nil {
+
+	if err := json.Unmarshal(md.Spec.Template.Spec.ProviderSpec.Value.Raw, &providerConfig); err != nil {
 		return fmt.Errorf("failed to decode provider config: %w", err)
 	}
 
@@ -618,7 +587,7 @@ func validateMachineDeployment(ctx context.Context, md *clusterv1alpha1.MachineD
 
 	// Ensure that OSP supports the operating system
 	if !supportedCloudProvider {
-		return fmt.Errorf("OperatingSystemProfile %q does not support cloud provider %q", osp.Name, providerConfig.OperatingSystem)
+		return fmt.Errorf("OperatingSystemProfile %q does not support cloud provider %q", osp.Name, providerConfig.CloudProvider)
 	}
 
 	return nil

--- a/pkg/controllers/osc/osc_reconciler_test.go
+++ b/pkg/controllers/osc/osc_reconciler_test.go
@@ -641,6 +641,215 @@ func TestOSCAndSecretRotation(t *testing.T) {
 	}
 }
 
+func TestOSCAndSecretRotationOnHashOrVersionChange(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		mutate               func(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, md *v1alpha1.MachineDeployment, osp *osmv1alpha1.OperatingSystemProfile)
+		verifyExpectedChange func(t *testing.T, oldHash, oldVersion, newHash, newVersion string)
+	}{
+		{
+			name: "rotates when machine deployment annotations hash changes",
+			mutate: func(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, md *v1alpha1.MachineDeployment, _ *osmv1alpha1.OperatingSystemProfile) {
+				md.Annotations["test.k8c.io/rotation-trigger"] = "updated"
+				if err := client.Update(ctx, md); err != nil {
+					t.Fatalf("failed to update machine deployment: %v", err)
+				}
+			},
+			verifyExpectedChange: func(t *testing.T, oldHash, oldVersion, newHash, newVersion string) {
+				if oldHash == newHash {
+					t.Fatal("expected machine deployment annotations hash to change")
+				}
+
+				if oldVersion != newVersion {
+					t.Fatal("expected OperatingSystemProfile version to stay unchanged")
+				}
+			},
+		},
+		{
+			name: "rotates when operating system profile version changes",
+			mutate: func(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, _ *v1alpha1.MachineDeployment, osp *osmv1alpha1.OperatingSystemProfile) {
+				osp.Spec.Version = osp.Spec.Version + ".1"
+				if err := client.Update(ctx, osp); err != nil {
+					t.Fatalf("failed to update OperatingSystemProfile: %v", err)
+				}
+			},
+			verifyExpectedChange: func(t *testing.T, oldHash, oldVersion, newHash, newVersion string) {
+				if oldVersion == newVersion {
+					t.Fatal("expected OperatingSystemProfile version to change")
+				}
+
+				if oldHash != newHash {
+					t.Fatal("expected machine deployment annotations hash to stay unchanged")
+				}
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.Background()
+			osp := &osmv1alpha1.OperatingSystemProfile{}
+			if err := loadFile(osp, defaultOSPPathPrefix+fmt.Sprintf("%s.yaml", ospUbuntu)); err != nil {
+				t.Fatalf("failed loading osp from testdata: %v", err)
+			}
+
+			md := generateMachineDeployment(
+				t,
+				"ubuntu-aws",
+				"kube-system",
+				ospUbuntu,
+				defaultKubeletVersion,
+				providerconfig.OperatingSystemUbuntu,
+				"aws",
+				runtime.RawExtension{Raw: []byte(`{"availabilityZone": "eu-central-1b", "vpcId": "e-123f", "subnetID": "test-subnet"}`)},
+				map[string]string{"test.k8c.io/static": "value"},
+				mcnet.IPFamilyIPv4,
+			)
+
+			objects := []ctrlruntimeclient.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster-info",
+						Namespace: "kube-public",
+					},
+					Data: map[string]string{"kubeconfig": clusterInfoKubeconfig},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cloud-init-getter-token",
+						Namespace: "cloud-init-settings",
+					},
+					Data: map[string][]byte{
+						"token": []byte("top-secret"),
+					},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bootstrap-token",
+						Namespace: "kube-system",
+						Labels:    map[string]string{"machinedeployment.k8s.io/name": "kube-system-ubuntu-aws"},
+					},
+					Data: map[string][]byte{
+						"token-id":     []byte("test"),
+						"token-secret": []byte("test"),
+						"expiration":   []byte(metav1.Now().Add(10 * time.Hour).Format(time.RFC3339)),
+					},
+				},
+				osp,
+				md,
+			}
+
+			fakeClient := ctrlruntimefakeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(objects...).
+				Build()
+
+			reconciler := buildReconciler(fakeClient, testConfig{namespace: "kube-system", containerRuntime: "containerd"})
+
+			if err := reconciler.reconcile(ctx, md); err != nil {
+				t.Fatalf("failed to reconcile: %v", err)
+			}
+
+			oscName := fmt.Sprintf(resources.OperatingSystemConfigNamePattern, md.Name, md.Namespace)
+			bootstrapSecretName := fmt.Sprintf(mcbootstrap.CloudConfigSecretNamePattern, md.Name, md.Namespace, mcbootstrap.BootstrapCloudConfig)
+			provisioningSecretName := fmt.Sprintf(mcbootstrap.CloudConfigSecretNamePattern, md.Name, md.Namespace, resources.ProvisioningCloudConfig)
+
+			osc := &osmv1alpha1.OperatingSystemConfig{}
+			if err := fakeClient.Get(ctx, types.NamespacedName{Namespace: "kube-system", Name: oscName}, osc); err != nil {
+				t.Fatalf("failed to get osc: %v", err)
+			}
+
+			bootstrapSecret := &corev1.Secret{}
+			if err := fakeClient.Get(ctx, types.NamespacedName{Namespace: mcbootstrap.CloudInitSettingsNamespace, Name: bootstrapSecretName}, bootstrapSecret); err != nil {
+				t.Fatalf("failed to get bootstrap secret: %v", err)
+			}
+
+			provisioningSecret := &corev1.Secret{}
+			if err := fakeClient.Get(ctx, types.NamespacedName{Namespace: mcbootstrap.CloudInitSettingsNamespace, Name: provisioningSecretName}, provisioningSecret); err != nil {
+				t.Fatalf("failed to get provisioning secret: %v", err)
+			}
+
+			oldHash := osc.Annotations[OperatingSystemConfigMDHash]
+			oldVersion := osc.Annotations[OperatingSystemConfigVersionAnnotation]
+
+			testCase.mutate(t, ctx, fakeClient, md, osp)
+
+			if err := fakeClient.Get(ctx, types.NamespacedName{Namespace: md.Namespace, Name: md.Name}, md); err != nil {
+				t.Fatalf("failed to refresh machine deployment: %v", err)
+			}
+
+			if err := fakeClient.Get(ctx, types.NamespacedName{Namespace: osp.Namespace, Name: osp.Name}, osp); err != nil {
+				t.Fatalf("failed to refresh OperatingSystemProfile: %v", err)
+			}
+
+			if err := reconciler.reconcile(ctx, md); err != nil {
+				t.Fatalf("failed to reconcile after update: %v", err)
+			}
+
+			if err := fakeClient.Get(ctx, types.NamespacedName{Namespace: "kube-system", Name: oscName}, osc); err != nil {
+				t.Fatalf("failed to get updated osc: %v", err)
+			}
+
+			if err := fakeClient.Get(ctx, types.NamespacedName{Namespace: mcbootstrap.CloudInitSettingsNamespace, Name: bootstrapSecretName}, bootstrapSecret); err != nil {
+				t.Fatalf("failed to get updated bootstrap secret: %v", err)
+			}
+
+			if err := fakeClient.Get(ctx, types.NamespacedName{Namespace: mcbootstrap.CloudInitSettingsNamespace, Name: provisioningSecretName}, provisioningSecret); err != nil {
+				t.Fatalf("failed to get updated provisioning secret: %v", err)
+			}
+
+			newHash := osc.Annotations[OperatingSystemConfigMDHash]
+			newVersion := osc.Annotations[OperatingSystemConfigVersionAnnotation]
+			testCase.verifyExpectedChange(t, oldHash, oldVersion, newHash, newVersion)
+
+			expectedRevision := md.Annotations[mcsdkcommon.RevisionAnnotation]
+			expectedHash, err := reconciler.calculateAnnotationsHash(md.Annotations)
+			if err != nil {
+				t.Fatalf("failed to calculate expected machine deployment annotations hash: %v", err)
+			}
+
+			expectedVersion := osp.Spec.Version
+
+			if expectedRevision != osc.Annotations[mcbootstrap.MachineDeploymentRevision] {
+				t.Fatal("revision for machine deployment and OSC didn't match")
+			}
+
+			if expectedHash != osc.Annotations[OperatingSystemConfigMDHash] {
+				t.Fatal("machine deployment annotations hash for machine deployment and OSC didn't match")
+			}
+
+			if expectedVersion != osc.Annotations[OperatingSystemConfigVersionAnnotation] {
+				t.Fatal("OperatingSystemProfile version for OSP and OSC didn't match")
+			}
+
+			if expectedRevision != bootstrapSecret.Annotations[mcbootstrap.MachineDeploymentRevision] {
+				t.Fatal("revision for machine deployment and bootstrap secret didn't match")
+			}
+
+			if expectedHash != bootstrapSecret.Annotations[OperatingSystemConfigMDHash] {
+				t.Fatal("machine deployment annotations hash for machine deployment and bootstrap secret didn't match")
+			}
+
+			if expectedVersion != bootstrapSecret.Annotations[OperatingSystemConfigVersionAnnotation] {
+				t.Fatal("OperatingSystemProfile version for OSP and bootstrap secret didn't match")
+			}
+
+			if expectedRevision != provisioningSecret.Annotations[mcbootstrap.MachineDeploymentRevision] {
+				t.Fatal("revision for machine deployment and provisioning secret didn't match")
+			}
+
+			if expectedHash != provisioningSecret.Annotations[OperatingSystemConfigMDHash] {
+				t.Fatal("machine deployment annotations hash for machine deployment and provisioning secret didn't match")
+			}
+
+			if expectedVersion != provisioningSecret.Annotations[OperatingSystemConfigVersionAnnotation] {
+				t.Fatal("OperatingSystemProfile version for OSP and provisioning secret didn't match")
+			}
+		})
+	}
+}
+
 func TestMachineDeploymentDeletion(t *testing.T) {
 	testCases := []struct {
 		name              string

--- a/pkg/controllers/osc/osc_reconciler_test.go
+++ b/pkg/controllers/osc/osc_reconciler_test.go
@@ -668,7 +668,7 @@ func TestOSCAndSecretRotationOnHashOrVersionChange(t *testing.T) {
 		{
 			name: "rotates when operating system profile version changes",
 			mutate: func(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, _ *v1alpha1.MachineDeployment, osp *osmv1alpha1.OperatingSystemProfile) {
-				osp.Spec.Version = osp.Spec.Version + ".1"
+				osp.Spec.Version += ".1"
 				if err := client.Update(ctx, osp); err != nil {
 					t.Fatalf("failed to update OperatingSystemProfile: %v", err)
 				}

--- a/pkg/controllers/osc/testdata/osc-flatcar-aws-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-flatcar-aws-containerd.yaml
@@ -3,6 +3,8 @@ kind: OperatingSystemConfig
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: bf61b23ba898e84e3e68ad8c36694f70e7fd3e3f3b8e69ac1ffc129bd38a0046
+    k8c.io/osp-version: v1.10.0
   name: flatcar-aws-containerd-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-kubelet-configuration-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-kubelet-configuration-containerd.yaml
@@ -3,6 +3,8 @@ kind: OperatingSystemConfig
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: db7ff021c8a496bfbf5511482e26a4a4039c99d745d9360c3d518f26f3b6ee2c
+    k8c.io/osp-version: v1.10.0
   name: kubelet-configuration-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-rhel-8.x-azure-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-rhel-8.x-azure-containerd.yaml
@@ -3,6 +3,8 @@ kind: OperatingSystemConfig
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: 80765e800a0186ae20232d6afa4b9a64163e5adbbc2c66ec9fb134f64fc7ed79
+    k8c.io/osp-version: v1.10.0
   name: osp-rhel-azure-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-rhel-8.x-cloud-init-modules.yaml
+++ b/pkg/controllers/osc/testdata/osc-rhel-8.x-cloud-init-modules.yaml
@@ -3,6 +3,8 @@ kind: OperatingSystemConfig
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: 4f7979f79c658b81c59f77f3f57073f57df2943d79f6a6821fc871b5f608e09c
+    k8c.io/osp-version: v1.10.0
   name: osp-rhel-aws-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-ubuntu-aws-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-aws-containerd.yaml
@@ -3,6 +3,8 @@ kind: OperatingSystemConfig
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
+    k8c.io/osp-version: v1.10.0
   name: ubuntu-aws-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack-IPv6+IPv4.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack-IPv6+IPv4.yaml
@@ -3,6 +3,8 @@ kind: OperatingSystemConfig
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
+    k8c.io/osp-version: v1.10.0
   name: ubuntu-aws-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack.yaml
@@ -3,6 +3,8 @@ kind: OperatingSystemConfig
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
+    k8c.io/osp-version: v1.10.0
   name: ubuntu-aws-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-ubuntu-openstack-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-openstack-containerd.yaml
@@ -3,6 +3,8 @@ kind: OperatingSystemConfig
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
+    k8c.io/osp-version: v1.10.0
   name: ubuntu-openstack-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-flatcar-aws-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-flatcar-aws-containerd-bootstrap.yaml
@@ -6,6 +6,8 @@ kind: Secret
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: bf61b23ba898e84e3e68ad8c36694f70e7fd3e3f3b8e69ac1ffc129bd38a0046
+    k8c.io/osp-version: v1.10.0
   name: flatcar-aws-containerd-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-flatcar-aws-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-flatcar-aws-containerd-provisioning.yaml
@@ -6,6 +6,8 @@ kind: Secret
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: bf61b23ba898e84e3e68ad8c36694f70e7fd3e3f3b8e69ac1ffc129bd38a0046
+    k8c.io/osp-version: v1.10.0
   name: flatcar-aws-containerd-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-kubelet-configuration-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-kubelet-configuration-containerd-bootstrap.yaml
@@ -6,6 +6,8 @@ kind: Secret
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: db7ff021c8a496bfbf5511482e26a4a4039c99d745d9360c3d518f26f3b6ee2c
+    k8c.io/osp-version: v1.10.0
   name: kubelet-configuration-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-kubelet-configuration-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-kubelet-configuration-containerd-provisioning.yaml
@@ -6,6 +6,8 @@ kind: Secret
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: db7ff021c8a496bfbf5511482e26a4a4039c99d745d9360c3d518f26f3b6ee2c
+    k8c.io/osp-version: v1.10.0
   name: kubelet-configuration-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-osc-rhel-8.x-cloud-init-modules-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-osc-rhel-8.x-cloud-init-modules-bootstrap.yaml
@@ -6,6 +6,8 @@ kind: Secret
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: 4f7979f79c658b81c59f77f3f57073f57df2943d79f6a6821fc871b5f608e09c
+    k8c.io/osp-version: v1.10.0
   name: osp-rhel-aws-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-osc-rhel-8.x-cloud-init-modules-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-osc-rhel-8.x-cloud-init-modules-provisioning.yaml
@@ -6,6 +6,8 @@ kind: Secret
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: 4f7979f79c658b81c59f77f3f57073f57df2943d79f6a6821fc871b5f608e09c
+    k8c.io/osp-version: v1.10.0
   name: osp-rhel-aws-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-rhel-8.x-azure-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-rhel-8.x-azure-containerd-bootstrap.yaml
@@ -6,6 +6,8 @@ kind: Secret
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: 80765e800a0186ae20232d6afa4b9a64163e5adbbc2c66ec9fb134f64fc7ed79
+    k8c.io/osp-version: v1.10.0
   name: osp-rhel-azure-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-rhel-8.x-azure-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-rhel-8.x-azure-containerd-provisioning.yaml
@@ -6,6 +6,8 @@ kind: Secret
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: 80765e800a0186ae20232d6afa4b9a64163e5adbbc2c66ec9fb134f64fc7ed79
+    k8c.io/osp-version: v1.10.0
   name: osp-rhel-azure-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-containerd-bootstrap.yaml
@@ -6,6 +6,8 @@ kind: Secret
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
+    k8c.io/osp-version: v1.10.0
   name: ubuntu-aws-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-containerd-provisioning.yaml
@@ -6,6 +6,8 @@ kind: Secret
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
+    k8c.io/osp-version: v1.10.0
   name: ubuntu-aws-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-IPv6+IPv4-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-IPv6+IPv4-bootstrap.yaml
@@ -6,6 +6,8 @@ kind: Secret
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
+    k8c.io/osp-version: v1.10.0
   name: ubuntu-aws-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-IPv6+IPv4-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-IPv6+IPv4-provisioning.yaml
@@ -6,6 +6,8 @@ kind: Secret
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
+    k8c.io/osp-version: v1.10.0
   name: ubuntu-aws-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-bootstrap.yaml
@@ -6,6 +6,8 @@ kind: Secret
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
+    k8c.io/osp-version: v1.10.0
   name: ubuntu-aws-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-provisioning.yaml
@@ -6,6 +6,8 @@ kind: Secret
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
+    k8c.io/osp-version: v1.10.0
   name: ubuntu-aws-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-openstack-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-openstack-containerd-bootstrap.yaml
@@ -6,6 +6,8 @@ kind: Secret
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
+    k8c.io/osp-version: v1.10.0
   name: ubuntu-openstack-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-openstack-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-openstack-containerd-provisioning.yaml
@@ -6,6 +6,8 @@ kind: Secret
 metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
+    k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
+    k8c.io/osp-version: v1.10.0
   name: ubuntu-openstack-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
https://github.com/kubermatic/operating-system-manager/issues/546 and possibly https://github.com/kubermatic/operating-system-manager/issues/207

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
more in the issue - we update OSP and MD annotations often, so we had some workarounds for this, but this should fix it for everybody. I need to re-test this patch as I use a slightly different version in our fork on older release

```release-note
Fix OSC and Secret rotation on updating an OSP or MachineDeployment annotations
```

**Documentation**:
```documentation
NONE
```
