### PR TITLE
Remove pod-infra-container-image flag from kubelet args, restores kubernetes 1.35 compatibility.

### DIFF
--- a/cmd/osm-controller/main.go
+++ b/cmd/osm-controller/main.go
@@ -310,7 +310,6 @@ func main() {
 		generator.NewDefaultCloudConfigGenerator(""),
 		opt.containerRuntime,
 		opt.externalCloudProvider,
-		opt.pauseImage,
 		opt.initialTaints,
 		opt.nodeHTTPProxy,
 		opt.nodeNoProxy,

--- a/deploy/osps/default/osp-amzn2.yaml
+++ b/deploy/osps/default/osp-amzn2.yaml
@@ -567,9 +567,6 @@ spec:
                 {{- else if and (eq .CloudProviderName "aws") (.ExternalCloudProvider) }}
                 --hostname-override=${KUBELET_HOSTNAME} \
                 {{- end }}
-                {{- if .PauseImage }}
-                --pod-infra-container-image={{ .PauseImage }} \
-                {{- end }}
                 {{- if .InitialTaints }}
                 --register-with-taints={{- .InitialTaints }} \
                 {{- end }}

--- a/deploy/osps/default/osp-flatcar-cloud-init.yaml
+++ b/deploy/osps/default/osp-flatcar-cloud-init.yaml
@@ -590,9 +590,6 @@ spec:
                 {{- else if and (eq .CloudProviderName "aws") (.ExternalCloudProvider) }}
                 --hostname-override=${KUBELET_HOSTNAME} \
                 {{- end }}
-                {{- if .PauseImage }}
-                --pod-infra-container-image={{ .PauseImage }} \
-                {{- end }}
                 {{- if .InitialTaints }}
                 --register-with-taints={{- .InitialTaints }} \
                 {{- end }}

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -764,9 +764,6 @@ spec:
                 {{- else if and (eq .CloudProviderName "aws") (.ExternalCloudProvider) }}
                 --hostname-override=${KUBELET_HOSTNAME} \
                 {{- end }}
-                {{- if .PauseImage }}
-                --pod-infra-container-image={{ .PauseImage }} \
-                {{- end }}
                 {{- if .InitialTaints }}
                 --register-with-taints={{- .InitialTaints }} \
                 {{- end }}

--- a/deploy/osps/default/osp-rhel.yaml
+++ b/deploy/osps/default/osp-rhel.yaml
@@ -610,9 +610,6 @@ spec:
                 {{- else if and (eq .CloudProviderName "aws") (.ExternalCloudProvider) }}
                 --hostname-override=${KUBELET_HOSTNAME} \
                 {{- end }}
-                {{- if .PauseImage }}
-                --pod-infra-container-image={{ .PauseImage }} \
-                {{- end }}
                 {{- if .InitialTaints }}
                 --register-with-taints={{- .InitialTaints }} \
                 {{- end }}

--- a/deploy/osps/default/osp-rockylinux.yaml
+++ b/deploy/osps/default/osp-rockylinux.yaml
@@ -618,9 +618,6 @@ spec:
                 {{- else if and (eq .CloudProviderName "aws") (.ExternalCloudProvider) }}
                 --hostname-override=${KUBELET_HOSTNAME} \
                 {{- end }}
-                {{- if .PauseImage }}
-                --pod-infra-container-image={{ .PauseImage }} \
-                {{- end }}
                 {{- if .InitialTaints }}
                 --register-with-taints={{- .InitialTaints }} \
                 {{- end }}

--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -644,9 +644,6 @@ spec:
                 {{- else if and (eq .CloudProviderName "aws") (.ExternalCloudProvider) }}
                 --hostname-override=${KUBELET_HOSTNAME} \
                 {{- end }}
-                {{- if .PauseImage }}
-                --pod-infra-container-image={{ .PauseImage }} \
-                {{- end }}
                 {{- if .InitialTaints }}
                 --register-with-taints={{- .InitialTaints }} \
                 {{- end }}

--- a/pkg/controllers/osc/osc_controller.go
+++ b/pkg/controllers/osc/osc_controller.go
@@ -68,7 +68,6 @@ type Reconciler struct {
 	namespace                     string
 	containerRuntime              string
 	externalCloudProvider         bool
-	pauseImage                    string
 	initialTaints                 string
 	generator                     generator.CloudConfigGenerator
 	clusterDNSIPs                 []net.IP
@@ -95,7 +94,6 @@ func Add(
 	generator generator.CloudConfigGenerator,
 	containerRuntime string,
 	externalCloudProvider bool,
-	pauseImage string,
 	initialTaints string,
 	nodeHTTPProxy string,
 	nodeNoProxy string,
@@ -115,7 +113,6 @@ func Add(
 		generator:                     generator,
 		clusterDNSIPs:                 clusterDNSIPs,
 		containerRuntime:              containerRuntime,
-		pauseImage:                    pauseImage,
 		initialTaints:                 initialTaints,
 		externalCloudProvider:         externalCloudProvider,
 		nodeHTTPProxy:                 nodeHTTPProxy,
@@ -265,7 +262,6 @@ func (r *Reconciler) reconcileOperatingSystemConfigs(ctx context.Context, md *cl
 		r.clusterDNSIPs,
 		r.containerRuntime,
 		r.externalCloudProvider,
-		r.pauseImage,
 		r.initialTaints,
 		r.nodeHTTPProxy,
 		r.nodeNoProxy,

--- a/pkg/controllers/osc/resources/operating_system_config.go
+++ b/pkg/controllers/osc/resources/operating_system_config.go
@@ -74,7 +74,6 @@ func GenerateOperatingSystemConfig(
 	clusterDNSIPs []net.IP,
 	containerRuntime string,
 	externalCloudProvider bool,
-	pauseImage string,
 	initialTaints string,
 	nodeHTTPProxy string,
 	nodeNoProxy string,
@@ -183,7 +182,6 @@ func GenerateOperatingSystemConfig(
 		ContainerRuntime:           containerRuntime,
 		CloudProviderName:          osmv1alpha1.CloudProvider(providerConfig.CloudProvider),
 		ExternalCloudProvider:      external,
-		PauseImage:                 pauseImage,
 		InitialTaints:              initialTaints,
 		ContainerRuntimeConfig:     crConfig,
 		ContainerRuntimeAuthConfig: crAuthConfig,
@@ -277,7 +275,6 @@ type filesData struct {
 	CloudProviderName          osmv1alpha1.CloudProvider
 	NetworkConfig              *providerconfig.NetworkConfig
 	ExternalCloudProvider      bool
-	PauseImage                 string
 	InitialTaints              string
 	HTTPProxy                  *string
 	NoProxy                    *string

--- a/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
+++ b/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
@@ -593,9 +593,6 @@ spec:
                 {{- end }}
                 --exit-on-lock-contention \
                 --lock-file=/tmp/kubelet.lock \
-                {{- if .PauseImage }}
-                --pod-infra-container-image={{ .PauseImage }} \
-                {{- end }}
                 {{- if .InitialTaints }}
                 --register-with-taints={{- .InitialTaints }} \
                 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
It's no longer necessary to set it, as this is handled by the container sandbox image param. The flag itself has been dropped from kubernetes 1.35.

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:
Removal notice: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md#no-really-you-must-read-this-before-you-upgrade

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove pod-infra-container-image flag from kubelet args, restores kubernetes 1.35 compatibility
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
