### PR TITLE
Fix duplicate SSH keys causing Flatcar nodes to boot-loop into emergency mode

### DIFF
--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -167,7 +167,7 @@ func (d *DefaultCloudConfigGenerator) Generate(config *osmv1alpha1.OSCConfig, pr
 
 // deduplicateSSHKeys normalizes and deduplicates SSH public keys while
 // preserving the first-seen order.
-// This prevents Ignition from rejecting configs with duplicates sshAuthorizedKeys entries.
+// This prevents Ignition from rejecting configs with duplicate sshAuthorizedKeys entries.
 func deduplicateSSHKeys(keys []string) []string {
 	seen := make(map[string]struct{})
 	result := []string{}

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -873,6 +873,11 @@ func TestDeduplicateSSHKeys(t *testing.T) {
 			expected: []string{},
 		},
 		{
+			name:     "nil list",
+			input:    nil,
+			expected: []string{},
+		},
+		{
 			name:     "three keys with one duplicate",
 			input:    []string{"ssh-rsa AAAA1", "ssh-rsa AAAA2\n", "ssh-rsa AAAA1\n"},
 			expected: []string{"ssh-rsa AAAA1", "ssh-rsa AAAA2"},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR deduplicates and trims SSH keys before rendering Ignition and cloud-init configs.

At the moment all copies of the SSH keys are passed into the generated Ignition config as separate `sshAuthorizedKeys` entries (this was observed during cluster provisioning in https://github.com/kubermatic/kubermatic/issues/15375). Flatcar's Ignition internally translates 2.x configs to spec 3.1, which strictly requires all SSH keys to be unique. The translation rejects the config with:
```
failed to fetch config: unable to translate 2.x ignition to 3.1: error at $.passwd.users.0.sshAuthorizedKeys.2: duplicate entry defined
```
This causes `ignition-fetch.service` to fail, the VM enters systemd emergency mode, reboots after 5 minutes, and repeats indefinitely. The node never joins the cluster, the Machine stays in `Provisioning` forever, and the only way to diagnose the issue is through the VM's serial console output.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/operating-system-manager/issues/564

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
The Ignition spec 3.1 requires that all SSH keys must be unique.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
SSH keys are now deduplicated and trimmed before rendering Ignition configs, preventing Flatcar nodes from boot-looping when duplicate keys with different whitespace exist in a project.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
