### PR TITLE
Drop Support Equinix Metal cloud provider support

### DIFF
--- a/deploy/crd/operatingsystemmanager.k8c.io_operatingsystemconfigs.yaml
+++ b/deploy/crd/operatingsystemmanager.k8c.io_operatingsystemconfigs.yaml
@@ -190,7 +190,6 @@ spec:
                     - linode
                     - nutanix
                     - openstack
-                    - equinixmetal
                     - vsphere
                     - fake
                     - alibaba

--- a/deploy/crd/operatingsystemmanager.k8c.io_operatingsystemprofiles.yaml
+++ b/deploy/crd/operatingsystemmanager.k8c.io_operatingsystemprofiles.yaml
@@ -478,7 +478,6 @@ spec:
                       - linode
                       - nutanix
                       - openstack
-                      - equinixmetal
                       - vsphere
                       - fake
                       - alibaba

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -26,7 +26,6 @@ spec:
   supportedCloudProviders:
     - name: "aws"
     - name: "azure"
-    - name: "equinixmetal"
     - name: "gce"
     - name: "kubevirt"
     - name: "openstack"

--- a/deploy/osps/default/osp-rockylinux.yaml
+++ b/deploy/osps/default/osp-rockylinux.yaml
@@ -26,7 +26,6 @@ spec:
     - name: "aws"
     - name: "azure"
     - name: "digitalocean"
-    - name: "equinixmetal"
     - name: "hetzner"
     - name: "openstack"
     - name: "kubevirt"

--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -29,7 +29,6 @@ spec:
     - name: "baremetal"
     - name: "digitalocean"
     - name: "edge"
-    - name: "equinixmetal"
     - name: "gce"
     - name: "hetzner"
     - name: "kubevirt"

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -16,7 +16,6 @@ Currently supported K8S versions are:
 | AWS | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Azure | ✓ | ✓ | x | ✓ | ✓ |
 | Digitalocean  | ✓ | x | x | x | ✓ |
-| Equinix Metal  | ✓ | ✓ | x | x | ✓ |
 | Google Cloud Platform | ✓ | ✓ | x | x | x |
 | Hetzner | ✓ | x | x | x | ✓ |
 | KubeVirt | ✓ | ✓ | x | ✓ | ✓ |

--- a/hack/kkp/operatingsystemmanager.k8c.io_customoperatingsystemprofiles.yaml
+++ b/hack/kkp/operatingsystemmanager.k8c.io_customoperatingsystemprofiles.yaml
@@ -441,7 +441,6 @@ spec:
                           - linode
                           - nutanix
                           - openstack
-                          - equinixmetal
                           - vsphere
                           - fake
                           - alibaba

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -68,7 +68,7 @@ func GetCloudConfig(external bool, pconfig providerconfig.Config, kubeletVersion
 
 	// cloud-config is not required for these cloud providers
 	case osmv1alpha1.CloudProviderAlibaba, osmv1alpha1.CloudProviderAnexia, osmv1alpha1.CloudProviderDigitalocean,
-		osmv1alpha1.CloudProviderHetzner, osmv1alpha1.CloudProviderLinode, osmv1alpha1.CloudProviderEquinixMetal,
+		osmv1alpha1.CloudProviderHetzner, osmv1alpha1.CloudProviderLinode,
 		osmv1alpha1.CloudProviderScaleway, osmv1alpha1.CloudProviderNutanix, osmv1alpha1.CloudProviderVMwareCloudDirector,
 		osmv1alpha1.CloudProviderOpenNebula, osmv1alpha1.CloudProviderEdge, osmv1alpha1.CloudProviderBaremetal:
 		return "", nil

--- a/pkg/crd/osm/v1alpha1/common_types.go
+++ b/pkg/crd/osm/v1alpha1/common_types.go
@@ -33,7 +33,7 @@ const (
 )
 
 // CloudProvider represents supported cloud provider.
-// +kubebuilder:validation:Enum=aws;azure;digitalocean;edge;gce;hetzner;kubevirt;linode;nutanix;openstack;equinixmetal;vsphere;fake;alibaba;anexia;scaleway;baremetal;external;vmware-cloud-director;opennebula
+// +kubebuilder:validation:Enum=aws;azure;digitalocean;edge;gce;hetzner;kubevirt;linode;nutanix;openstack;vsphere;fake;alibaba;anexia;scaleway;baremetal;external;vmware-cloud-director;opennebula
 type CloudProvider string
 
 const (
@@ -44,7 +44,6 @@ const (
 	CloudProviderBaremetal           CloudProvider = "baremetal"
 	CloudProviderDigitalocean        CloudProvider = "digitalocean"
 	CloudProviderEdge                CloudProvider = "edge"
-	CloudProviderEquinixMetal        CloudProvider = "equinixmetal"
 	CloudProviderExternal            CloudProvider = "external"
 	CloudProviderFake                CloudProvider = "fake"
 	CloudProviderGoogle              CloudProvider = "gce"

--- a/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Operating System Manager contributors.
+Copyright 2026 The Operating System Manager contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes Equinix Metal (equinixmetal) as a supported cloud provider from OSM.

FYI: This cloud provider has been deprecated in v2.29

#### Dashboard Repo
- https://github.com/kubermatic/dashboard/pull/7533/changes

#### Kubermatic Repo
- https://github.com/kubermatic/kubermatic/pull/15317/changes
- https://github.com/kubermatic/kubermatic/pull/14827/changes
- https://github.com/kubermatic/kubermatic/pull/15064/changes


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Removed Equinix Metal cloud provider support from Operating System Manager.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
