### PR TITLE
Bump default OSP version to v1.11.0, update Go version to v1.26.5 and MC SDK Go dependency to v1.66.1

### DIFF
--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -26,7 +26,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-9
           command:
             - /bin/bash
             - -c
@@ -53,7 +53,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-9
           command:
             - "./hack/ci/upload-gocache.sh"
           resources:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-1
+        - image: quay.io/kubermatic/build:go-1.26-node-22-9
           command:
             - make
           args:
@@ -36,7 +36,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-1
+        - image: quay.io/kubermatic/build:go-1.26-node-22-9
           command:
             - make
           args:
@@ -58,7 +58,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-1
+        - image: quay.io/kubermatic/build:go-1.26-node-22-9
           command:
             - make
           args:
@@ -79,7 +79,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-1
+        - image: quay.io/kubermatic/build:go-1.26-node-22-9
           command:
             - ./hack/verify-licenses.sh
           resources:
@@ -95,7 +95,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-1
+        - image: quay.io/kubermatic/build:go-1.26-node-22-9
           command:
             - make
           args:
@@ -110,7 +110,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/operating-system-manager.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-1
+        - image: quay.io/kubermatic/build:go-1.26-node-22-9
           command:
             - shfmt
           args:
@@ -141,7 +141,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-1
+        - image: quay.io/kubermatic/build:go-1.26-node-22-9
           command:
             - make
           args:
@@ -162,7 +162,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           resources:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 FROM golang:${GO_VERSION} AS builder
 WORKDIR /go/src/k8c.io/operating-system-manager
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ export GO111MODULE=on
 export GOFLAGS?=-mod=readonly -trimpath
 export GIT_TAG ?= $(shell git tag --points-at HEAD)
 
-GO_VERSION = 1.26.4
+GO_VERSION = 1.26.5
 
 CMD = $(notdir $(wildcard ./cmd/*))
 BUILD_DEST ?= _build

--- a/deploy/osps/default/osp-amzn2.yaml
+++ b/deploy/osps/default/osp-amzn2.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "amzn2"
   osVersion: "2.0"
-  version: "v1.10.0"
+  version: "v1.11.0"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-flatcar-cloud-init.yaml
+++ b/deploy/osps/default/osp-flatcar-cloud-init.yaml
@@ -21,7 +21,7 @@ spec:
   osName: flatcar
   ## Flatcar Stable (09/11/2021)
   osVersion: "2983.2.0"
-  version: "v1.10.0"
+  version: "v1.11.0"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "anexia"

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -21,7 +21,7 @@ spec:
   osName: flatcar
   ## Flatcar Stable (09/11/2021)
   osVersion: "2983.2.0"
-  version: "v1.10.0"
+  version: "v1.11.0"
   provisioningUtility: "ignition"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-rhel.yaml
+++ b/deploy/osps/default/osp-rhel.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "rhel"
   osVersion: "9.5"
-  version: "v1.10.0"
+  version: "v1.11.0"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-rockylinux.yaml
+++ b/deploy/osps/default/osp-rockylinux.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "rockylinux"
   osVersion: "9.6"
-  version: "v1.10.0"
+  version: "v1.11.0"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "ubuntu"
   osVersion: "24.04"
-  version: "v1.10.0"
+  version: "v1.11.0"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "alibaba"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8c.io/operating-system-manager
 
-go 1.26.0
+go 1.26.5
 
 replace github.com/ajeddeloh/go-json => github.com/coreos/go-json v0.0.0-20231102161613-e49c8866685a
 
@@ -18,7 +18,7 @@ require (
 	go.uber.org/zap v1.27.1
 	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/yaml.v3 v3.0.1
-	k8c.io/machine-controller/sdk v1.64.1
+	k8c.io/machine-controller/sdk v1.66.1
 	k8c.io/reconciler v0.5.0
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2

--- a/go.sum
+++ b/go.sum
@@ -561,8 +561,8 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
-k8c.io/machine-controller/sdk v1.64.1 h1:FXCn6sEjy+0p6xQs3om4Ld7DFQfBjinedBTFLoqyka0=
-k8c.io/machine-controller/sdk v1.64.1/go.mod h1:/5eWTMcfa7mTQUQoqziaalViiHSVzqzy3fXjejT1qLg=
+k8c.io/machine-controller/sdk v1.66.1 h1:dUrNbXUfj/xrmgajCTDFuZj4zsaPyIzBkB0ZxsIkSh4=
+k8c.io/machine-controller/sdk v1.66.1/go.mod h1:/5eWTMcfa7mTQUQoqziaalViiHSVzqzy3fXjejT1qLg=
 k8c.io/reconciler v0.5.0 h1:BHpelg1UfI/7oBFctqOq8sX6qzflXpl3SlvHe7e8wak=
 k8c.io/reconciler v0.5.0/go.mod h1:pT1+SVcVXJQeBJhpJBXQ5XW64QnKKeYTnVlQf0dGE0k=
 k8s.io/api v0.36.2 h1:TF6YDLIzKfccK7cq9YpTcGX8TJmEkHVRv78DM51fRYY=

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-1 containerize ./hack/update-codegen.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-9 containerize ./hack/update-codegen.sh
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 
 sed="sed"

--- a/hack/update-crds-openapi.sh
+++ b/hack/update-crds-openapi.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-1 containerize ./hack/update-crds-openapi.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-9 containerize ./hack/update-crds-openapi.sh
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 
 echodate "Creating vendor directory"

--- a/hack/update-fixtures.sh
+++ b/hack/update-fixtures.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-1 containerize ./hack/update-fixtures.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-9 containerize ./hack/update-fixtures.sh
 
 go test -v ./... -update || go test -v ./...
 

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-1 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-9 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/pkg/controllers/osc/testdata/osc-flatcar-aws-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-flatcar-aws-containerd.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: bf61b23ba898e84e3e68ad8c36694f70e7fd3e3f3b8e69ac1ffc129bd38a0046
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: flatcar-aws-containerd-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-kubelet-configuration-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-kubelet-configuration-containerd.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: db7ff021c8a496bfbf5511482e26a4a4039c99d745d9360c3d518f26f3b6ee2c
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: kubelet-configuration-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-rhel-8.x-azure-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-rhel-8.x-azure-containerd.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 80765e800a0186ae20232d6afa4b9a64163e5adbbc2c66ec9fb134f64fc7ed79
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: osp-rhel-azure-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-rhel-8.x-cloud-init-modules.yaml
+++ b/pkg/controllers/osc/testdata/osc-rhel-8.x-cloud-init-modules.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 4f7979f79c658b81c59f77f3f57073f57df2943d79f6a6821fc871b5f608e09c
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: osp-rhel-aws-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-ubuntu-aws-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-aws-containerd.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: ubuntu-aws-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack-IPv6+IPv4.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack-IPv6+IPv4.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: ubuntu-aws-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: ubuntu-aws-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-ubuntu-openstack-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-openstack-containerd.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: ubuntu-openstack-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
+++ b/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "rhel"
   osVersion: "8.5"
-  version: "v1.10.0"
+  version: "v1.11.0"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"

--- a/pkg/controllers/osc/testdata/secret-flatcar-aws-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-flatcar-aws-containerd-bootstrap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: bf61b23ba898e84e3e68ad8c36694f70e7fd3e3f3b8e69ac1ffc129bd38a0046
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: flatcar-aws-containerd-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-flatcar-aws-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-flatcar-aws-containerd-provisioning.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: bf61b23ba898e84e3e68ad8c36694f70e7fd3e3f3b8e69ac1ffc129bd38a0046
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: flatcar-aws-containerd-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-kubelet-configuration-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-kubelet-configuration-containerd-bootstrap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: db7ff021c8a496bfbf5511482e26a4a4039c99d745d9360c3d518f26f3b6ee2c
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: kubelet-configuration-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-kubelet-configuration-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-kubelet-configuration-containerd-provisioning.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: db7ff021c8a496bfbf5511482e26a4a4039c99d745d9360c3d518f26f3b6ee2c
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: kubelet-configuration-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-osc-rhel-8.x-cloud-init-modules-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-osc-rhel-8.x-cloud-init-modules-bootstrap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 4f7979f79c658b81c59f77f3f57073f57df2943d79f6a6821fc871b5f608e09c
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: osp-rhel-aws-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-osc-rhel-8.x-cloud-init-modules-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-osc-rhel-8.x-cloud-init-modules-provisioning.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 4f7979f79c658b81c59f77f3f57073f57df2943d79f6a6821fc871b5f608e09c
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: osp-rhel-aws-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-rhel-8.x-azure-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-rhel-8.x-azure-containerd-bootstrap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 80765e800a0186ae20232d6afa4b9a64163e5adbbc2c66ec9fb134f64fc7ed79
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: osp-rhel-azure-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-rhel-8.x-azure-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-rhel-8.x-azure-containerd-provisioning.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 80765e800a0186ae20232d6afa4b9a64163e5adbbc2c66ec9fb134f64fc7ed79
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: osp-rhel-azure-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-containerd-bootstrap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: ubuntu-aws-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-containerd-provisioning.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: ubuntu-aws-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-IPv6+IPv4-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-IPv6+IPv4-bootstrap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: ubuntu-aws-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-IPv6+IPv4-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-IPv6+IPv4-provisioning.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: ubuntu-aws-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-bootstrap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: ubuntu-aws-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-provisioning.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: ubuntu-aws-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-openstack-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-openstack-containerd-bootstrap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: ubuntu-openstack-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-openstack-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-openstack-containerd-provisioning.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.10.0
+    k8c.io/osp-version: v1.11.0
   name: ubuntu-openstack-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump default OSP version to v1.11.0, update Go version to v1.26.5 and MC SDK Go dependency to v1.66.1

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #626

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update Go version to v1.26.5
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
