### PR TITLE
Add missing RBAC to use EndpointSlices instead of Endpoints

### DIFF
--- a/deploy/rbac-controller.yaml
+++ b/deploy/rbac-controller.yaml
@@ -89,13 +89,13 @@ metadata:
   namespace: default
 rules:
   - apiGroups:
-      - ""
+      - discovery.k8s.io
     resources:
-      - endpoints
-    resourceNames:
-      - kubernetes
+      - endpointslices
     verbs:
       - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
**What this PR does / why we need it**:
After [migration to the EndpointSlices](https://github.com/kubermatic/operating-system-manager/pull/552) RBAC rule was missing.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #599

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add missing RBAC to use EndpointSlices instead of Endpoints
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
