### PR TITLE
[release/v1.10] Update default OSPs to version v1.10.9

### DIFF
--- a/deploy/osps/default/osp-amzn2.yaml
+++ b/deploy/osps/default/osp-amzn2.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "amzn2"
   osVersion: "2.0"
-  version: "v1.10.7"
+  version: "v1.10.9"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-flatcar-cloud-init.yaml
+++ b/deploy/osps/default/osp-flatcar-cloud-init.yaml
@@ -21,7 +21,7 @@ spec:
   osName: flatcar
   ## Flatcar Stable (09/11/2021)
   osVersion: "2983.2.0"
-  version: "v1.10.7"
+  version: "v1.10.9"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "anexia"

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -21,7 +21,7 @@ spec:
   osName: flatcar
   ## Flatcar Stable (09/11/2021)
   osVersion: "2983.2.0"
-  version: "v1.10.7"
+  version: "v1.10.9"
   provisioningUtility: "ignition"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-rhel.yaml
+++ b/deploy/osps/default/osp-rhel.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "rhel"
   osVersion: "9.5"
-  version: "v1.10.7"
+  version: "v1.10.9"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-rockylinux.yaml
+++ b/deploy/osps/default/osp-rockylinux.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "rockylinux"
   osVersion: "9.6"
-  version: "v1.10.7"
+  version: "v1.10.9"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "ubuntu"
   osVersion: "24.04"
-  version: "v1.10.7"
+  version: "v1.10.9"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "alibaba"

--- a/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
+++ b/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "rhel"
   osVersion: "8.5"
-  version: "v1.10.7"
+  version: "v1.10.9"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"


### PR DESCRIPTION
**What this PR does / why we need it**:
The default OSPs compiled into the image still carry `v1.10.7`; the v1.10.8 release skipped the version bump. This updates `spec.version` in all six default OSPs to `v1.10.9`. No fixture regen is needed: on this branch the OSC reconciler does not stamp the `k8c.io/osp-version` annotation, so the golden files are unaffected.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```