### PR TITLE
Update default OSPs to version v1.11.4

### DIFF
--- a/deploy/osps/default/osp-amzn2.yaml
+++ b/deploy/osps/default/osp-amzn2.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "amzn2"
   osVersion: "2.0"
-  version: "v1.11.2"
+  version: "v1.11.4"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-flatcar-cloud-init.yaml
+++ b/deploy/osps/default/osp-flatcar-cloud-init.yaml
@@ -21,7 +21,7 @@ spec:
   osName: flatcar
   ## Flatcar Stable (09/11/2021)
   osVersion: "2983.2.0"
-  version: "v1.11.2"
+  version: "v1.11.4"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "anexia"

--- a/deploy/osps/default/osp-flatcar.yaml
+++ b/deploy/osps/default/osp-flatcar.yaml
@@ -21,7 +21,7 @@ spec:
   osName: flatcar
   ## Flatcar Stable (09/11/2021)
   osVersion: "2983.2.0"
-  version: "v1.11.2"
+  version: "v1.11.4"
   provisioningUtility: "ignition"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-rhel.yaml
+++ b/deploy/osps/default/osp-rhel.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "rhel"
   osVersion: "9.5"
-  version: "v1.11.2"
+  version: "v1.11.4"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-rockylinux.yaml
+++ b/deploy/osps/default/osp-rockylinux.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "rockylinux"
   osVersion: "9.6"
-  version: "v1.11.2"
+  version: "v1.11.4"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"

--- a/deploy/osps/default/osp-ubuntu.yaml
+++ b/deploy/osps/default/osp-ubuntu.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "ubuntu"
   osVersion: "24.04"
-  version: "v1.11.2"
+  version: "v1.11.4"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "alibaba"

--- a/pkg/controllers/osc/testdata/osc-flatcar-aws-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-flatcar-aws-containerd.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: bf61b23ba898e84e3e68ad8c36694f70e7fd3e3f3b8e69ac1ffc129bd38a0046
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: flatcar-aws-containerd-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-kubelet-configuration-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-kubelet-configuration-containerd.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: db7ff021c8a496bfbf5511482e26a4a4039c99d745d9360c3d518f26f3b6ee2c
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: kubelet-configuration-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-rhel-8.x-azure-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-rhel-8.x-azure-containerd.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 80765e800a0186ae20232d6afa4b9a64163e5adbbc2c66ec9fb134f64fc7ed79
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: osp-rhel-azure-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-rhel-8.x-cloud-init-modules.yaml
+++ b/pkg/controllers/osc/testdata/osc-rhel-8.x-cloud-init-modules.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 4f7979f79c658b81c59f77f3f57073f57df2943d79f6a6821fc871b5f608e09c
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: osp-rhel-aws-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-ubuntu-aws-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-aws-containerd.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: ubuntu-aws-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack-IPv6+IPv4.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack-IPv6+IPv4.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: ubuntu-aws-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-aws-dualstack.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: ubuntu-aws-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osc-ubuntu-openstack-containerd.yaml
+++ b/pkg/controllers/osc/testdata/osc-ubuntu-openstack-containerd.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: ubuntu-openstack-kube-system-config
   namespace: kube-system
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
+++ b/pkg/controllers/osc/testdata/osp-rhel-aws-cloud-init-modules.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   osName: "rhel"
   osVersion: "8.5"
-  version: "v1.11.2"
+  version: "v1.11.4"
   provisioningUtility: "cloud-init"
   supportedCloudProviders:
     - name: "aws"

--- a/pkg/controllers/osc/testdata/secret-flatcar-aws-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-flatcar-aws-containerd-bootstrap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: bf61b23ba898e84e3e68ad8c36694f70e7fd3e3f3b8e69ac1ffc129bd38a0046
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: flatcar-aws-containerd-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-flatcar-aws-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-flatcar-aws-containerd-provisioning.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: bf61b23ba898e84e3e68ad8c36694f70e7fd3e3f3b8e69ac1ffc129bd38a0046
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: flatcar-aws-containerd-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-kubelet-configuration-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-kubelet-configuration-containerd-bootstrap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: db7ff021c8a496bfbf5511482e26a4a4039c99d745d9360c3d518f26f3b6ee2c
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: kubelet-configuration-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-kubelet-configuration-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-kubelet-configuration-containerd-provisioning.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: db7ff021c8a496bfbf5511482e26a4a4039c99d745d9360c3d518f26f3b6ee2c
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: kubelet-configuration-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-osc-rhel-8.x-cloud-init-modules-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-osc-rhel-8.x-cloud-init-modules-bootstrap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 4f7979f79c658b81c59f77f3f57073f57df2943d79f6a6821fc871b5f608e09c
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: osp-rhel-aws-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-osc-rhel-8.x-cloud-init-modules-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-osc-rhel-8.x-cloud-init-modules-provisioning.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 4f7979f79c658b81c59f77f3f57073f57df2943d79f6a6821fc871b5f608e09c
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: osp-rhel-aws-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-rhel-8.x-azure-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-rhel-8.x-azure-containerd-bootstrap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 80765e800a0186ae20232d6afa4b9a64163e5adbbc2c66ec9fb134f64fc7ed79
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: osp-rhel-azure-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-rhel-8.x-azure-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-rhel-8.x-azure-containerd-provisioning.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 80765e800a0186ae20232d6afa4b9a64163e5adbbc2c66ec9fb134f64fc7ed79
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: osp-rhel-azure-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-containerd-bootstrap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: ubuntu-aws-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-containerd-provisioning.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: ubuntu-aws-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-IPv6+IPv4-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-IPv6+IPv4-bootstrap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: ubuntu-aws-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-IPv6+IPv4-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-IPv6+IPv4-provisioning.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: ubuntu-aws-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-bootstrap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: ubuntu-aws-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-aws-dualstack-provisioning.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: ubuntu-aws-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-openstack-containerd-bootstrap.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-openstack-containerd-bootstrap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: ubuntu-openstack-kube-system-bootstrap-config
   namespace: cloud-init-settings
   resourceVersion: "1"

--- a/pkg/controllers/osc/testdata/secret-ubuntu-openstack-containerd-provisioning.yaml
+++ b/pkg/controllers/osc/testdata/secret-ubuntu-openstack-containerd-provisioning.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     k8c.io/machine-deployment-revision: "1"
     k8c.io/mdannotations-hash: 240e92a138b73a540fc8f38a171c511995e6c10890b9af15f92f5a8b84136765
-    k8c.io/osp-version: v1.11.2
+    k8c.io/osp-version: v1.11.4
   name: ubuntu-openstack-kube-system-provisioning-config
   namespace: cloud-init-settings
   resourceVersion: "1"


### PR DESCRIPTION
**What this PR does / why we need it**:
The default OSPs on `main` still carry `v1.11.2`. This updates `spec.version` in all six default OSPs to `v1.11.4`, matching the release branch, and regenerates the OSC controller fixtures so the `k8c.io/osp-version` annotation on the golden files matches.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```